### PR TITLE
Add auto-generated quests for mods

### DIFF
--- a/Survie/minecraft/config/ftbquests/quests/chapters/mods_explore_gen.snbt
+++ b/Survie/minecraft/config/ftbquests/quests/chapters/mods_explore_gen.snbt
@@ -1,0 +1,738 @@
+{
+        id: "A596B363AC15487A8FCAA1733605342A"
+        group: ""
+        order_index: 4
+        filename: "mods_explore_gen"
+        title: "Exploration"
+        icon: {
+                id: "minecraft:compass"
+                Count: 1b
+        }
+        default_quest_shape: ""
+        default_hide_dependency_lines: false
+        quests: [
+                {
+                        x: 0.0d
+                        y: 0.0d
+                        id: "F6ADAA8324254B728DB468EEB232FB6B"
+                        tasks: [
+                                {
+                                        id: "C9815BEA9ED049C1B9EA1B846A477ED9"
+                                        type: "item"
+                                        title: "D\u00e9couvrir Beyond-Earth-1.18.2-6.2"
+                                        icon: {
+                                                id: "beyond_earth:alien"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "beyond_earth:alien"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "D128752886764D4F899FF10AED45E67F"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 0.0d
+                        y: 2.0d
+                        id: "1F615C2A792E472BA8C15842A5D96FA9"
+                        tasks: [
+                                {
+                                        id: "C930E86A0AD34FEEA1DB84E01224682E"
+                                        type: "item"
+                                        title: "Approfondir Beyond-Earth-1.18.2-6.2"
+                                        icon: {
+                                                id: "beyond_earth:alien_spawn_egg"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "beyond_earth:alien_spawn_egg"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "7DD987CEC86E46BA8BCECFD598B8AF2C"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "F6ADAA8324254B728DB468EEB232FB6B"
+                        ]
+                },
+                {
+                        x: 0.0d
+                        y: 4.0d
+                        id: "164A8818F9A44159955EC4E972F120B1"
+                        tasks: [
+                                {
+                                        id: "3ACDCC1D264143A6B2C0A16AC52AF116"
+                                        type: "item"
+                                        title: "Ma\u00eetriser Beyond-Earth-1.18.2-6.2"
+                                        icon: {
+                                                id: "beyond_earth:alien_spit_entity"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "beyond_earth:alien_spit_entity"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "BF3E30CECF7E4EBEA93907B4DFB55275"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "1F615C2A792E472BA8C15842A5D96FA9"
+                        ]
+                },
+                {
+                        x: 4.0d
+                        y: 0.0d
+                        id: "9069911D39F74627946F2558AAE105A4"
+                        tasks: [
+                                {
+                                        id: "0E857DEF272F47848D9E336F8B363190"
+                                        type: "item"
+                                        title: "D\u00e9couvrir Beyond-Earth-Giselle-Addon-1.18.2-2.20"
+                                        icon: {
+                                                id: "beyond_earth_giselle_addon:advanced_compressor"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "beyond_earth_giselle_addon:advanced_compressor"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "5D022DBE9B68455C85803A1A1513AE3E"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 4.0d
+                        y: 2.0d
+                        id: "069EC42F501943DFB641BD2857F358A3"
+                        tasks: [
+                                {
+                                        id: "8EFAC62C1561497DB4EBD4233FB7B212"
+                                        type: "item"
+                                        title: "Approfondir Beyond-Earth-Giselle-Addon-1.18.2-2.20"
+                                        icon: {
+                                                id: "beyond_earth_giselle_addon:electric_blast_furnace"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "beyond_earth_giselle_addon:electric_blast_furnace"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "3DDFDFD4B2CA490A9EF15A1A4E11482A"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "9069911D39F74627946F2558AAE105A4"
+                        ]
+                },
+                {
+                        x: 4.0d
+                        y: 4.0d
+                        id: "07ED43E42CE247899B39DFFC4CF91348"
+                        tasks: [
+                                {
+                                        id: "595D004105A54B9892F619B0EC50D76F"
+                                        type: "item"
+                                        title: "Ma\u00eetriser Beyond-Earth-Giselle-Addon-1.18.2-2.20"
+                                        icon: {
+                                                id: "beyond_earth_giselle_addon:fuel_loader"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "beyond_earth_giselle_addon:fuel_loader"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "1F978EBD5E7045C4BC9D10919016AF26"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "069EC42F501943DFB641BD2857F358A3"
+                        ]
+                },
+                {
+                        x: 8.0d
+                        y: 0.0d
+                        id: "E20078E5296F4F1186491B152BD07AD7"
+                        tasks: [
+                                {
+                                        id: "404ECED70ED441C7802FB6E8234A208A"
+                                        type: "item"
+                                        title: "D\u00e9couvrir EnderStorage-1.18.2-2.9.0.182-universal"
+                                        icon: {
+                                                id: "enderstorage:ender_chest"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "enderstorage:ender_chest"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "1D1690128B9E4071B85939229BB34A49"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 8.0d
+                        y: 2.0d
+                        id: "B1F73A9ED2D14CB8AB55E20813D071B5"
+                        tasks: [
+                                {
+                                        id: "D66C75BFF40E4BAA8925B81A1209320D"
+                                        type: "item"
+                                        title: "Approfondir EnderStorage-1.18.2-2.9.0.182-universal"
+                                        icon: {
+                                                id: "enderstorage:ender_pouch"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "enderstorage:ender_pouch"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "C41A4DC83AF845DD8D65B484032676CB"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "E20078E5296F4F1186491B152BD07AD7"
+                        ]
+                },
+                {
+                        x: 8.0d
+                        y: 4.0d
+                        id: "DAF72C66BE474FD0A120508FCDA6E290"
+                        tasks: [
+                                {
+                                        id: "246F93321E4249C2A9103950C0D2126E"
+                                        type: "item"
+                                        title: "Ma\u00eetriser EnderStorage-1.18.2-2.9.0.182-universal"
+                                        icon: {
+                                                id: "enderstorage:ender_tank"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "enderstorage:ender_tank"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "D7598AF4067743E7A59BB6C8502FA448"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "B1F73A9ED2D14CB8AB55E20813D071B5"
+                        ]
+                },
+                {
+                        x: 12.0d
+                        y: 0.0d
+                        id: "C57AFBC92C254B86A4B7CDD614B38185"
+                        tasks: [
+                                {
+                                        id: "1FE9455237044D2181AE3C62A621C1D7"
+                                        type: "item"
+                                        title: "D\u00e9couvrir dungeons_gear-1.18.2-4.0.2-beta"
+                                        icon: {
+                                                id: "dungeons_gear:anchor"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "dungeons_gear:anchor"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "83881977749A4A55AB30ED9012838143"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 12.0d
+                        y: 2.0d
+                        id: "3A9393B4FB2846F1B7EDCEA014F9A5B2"
+                        tasks: [
+                                {
+                                        id: "6693523CA7DC484C9F9A9D8CF5704890"
+                                        type: "item"
+                                        title: "Approfondir dungeons_gear-1.18.2-4.0.2-beta"
+                                        icon: {
+                                                id: "dungeons_gear:ancient_bow"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "dungeons_gear:ancient_bow"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "FF7DEA99497140B283EC379EC28A2C75"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "C57AFBC92C254B86A4B7CDD614B38185"
+                        ]
+                },
+                {
+                        x: 12.0d
+                        y: 4.0d
+                        id: "0ABAD93059CA4990B9C5BC2DB449B703"
+                        tasks: [
+                                {
+                                        id: "388EDDF7353342A3A8D269AEE706A36A"
+                                        type: "item"
+                                        title: "Ma\u00eetriser dungeons_gear-1.18.2-4.0.2-beta"
+                                        icon: {
+                                                id: "dungeons_gear:ancient_bow_pulling_0"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "dungeons_gear:ancient_bow_pulling_0"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "E961CAA369D445C892FB7D4A18B5832F"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "3A9393B4FB2846F1B7EDCEA014F9A5B2"
+                        ]
+                },
+                {
+                        x: 16.0d
+                        y: 0.0d
+                        id: "F31197DC033E4CC79344DB6698FA9A7B"
+                        tasks: [
+                                {
+                                        id: "117AFB15B54545F4A41BA4C8E714E549"
+                                        type: "item"
+                                        title: "D\u00e9couvrir dungeons_plus-1.18.2-1.2.0"
+                                        icon: {
+                                                id: "dungeons_plus:frosted_cowl"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "dungeons_plus:frosted_cowl"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "9F2F163970F84B358CC1EBE220E1D3CD"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 16.0d
+                        y: 2.0d
+                        id: "E5875BB9D4914EA493876FB1792A4AB8"
+                        tasks: [
+                                {
+                                        id: "7B93BF842B504C1D9859908C63DCA5E7"
+                                        type: "item"
+                                        title: "Approfondir dungeons_plus-1.18.2-1.2.0"
+                                        icon: {
+                                                id: "dungeons_plus:leviathan_blade"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "dungeons_plus:leviathan_blade"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "BA06BCFFB49C43FC9AB3F8DA132049B0"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "F31197DC033E4CC79344DB6698FA9A7B"
+                        ]
+                },
+                {
+                        x: 16.0d
+                        y: 4.0d
+                        id: "F1ACBEA0031D4AF5AB8315D09291E6CC"
+                        tasks: [
+                                {
+                                        id: "EAAD9D90044C439D98AF3F4043EA55FC"
+                                        type: "item"
+                                        title: "Ma\u00eetriser dungeons_plus-1.18.2-1.2.0"
+                                        icon: {
+                                                id: "dungeons_plus:soul_cannon"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "dungeons_plus:soul_cannon"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "F333E3C5D4CE48948F7E90BB4C2E9B8F"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "E5875BB9D4914EA493876FB1792A4AB8"
+                        ]
+                },
+                {
+                        x: 20.0d
+                        y: 0.0d
+                        id: "A8A6049E3358483EBBE78FE11746A72C"
+                        tasks: [
+                                {
+                                        id: "B1C2E6836CE34B8AA05EF00ECF0DB582"
+                                        type: "item"
+                                        title: "D\u00e9couvrir ftb-quests-forge-1802.3.16-build.479"
+                                        icon: {
+                                                id: "ftbquests:banner"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "ftbquests:banner"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "88BD649646BC4D3D9BF7190C1745A3A5"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 20.0d
+                        y: 2.0d
+                        id: "97BDC85AC0D441F59B14D265E398D612"
+                        tasks: [
+                                {
+                                        id: "9B9C0E3E7FB742B9B1C61BEC9AFCEA9C"
+                                        type: "item"
+                                        title: "Approfondir ftb-quests-forge-1802.3.16-build.479"
+                                        icon: {
+                                                id: "ftbquests:barrier"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "ftbquests:barrier"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "D97412B3B57548D1880CCB3A1DC204AA"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "A8A6049E3358483EBBE78FE11746A72C"
+                        ]
+                },
+                {
+                        x: 20.0d
+                        y: 4.0d
+                        id: "622C8C8B687E4953AEF5FC2A2380908B"
+                        tasks: [
+                                {
+                                        id: "3926F110F17E4AD89BDE0F4CF661563C"
+                                        type: "item"
+                                        title: "Ma\u00eetriser ftb-quests-forge-1802.3.16-build.479"
+                                        icon: {
+                                                id: "ftbquests:book"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "ftbquests:book"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "3853A8658245494EAD1D4EC87E5ED920"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "97BDC85AC0D441F59B14D265E398D612"
+                        ]
+                },
+                {
+                        x: 24.0d
+                        y: 0.0d
+                        id: "84150CEF79644E4283C7862FAE5DDB9F"
+                        tasks: [
+                                {
+                                        id: "27643238C8DE4ED99D94B288A455B720"
+                                        type: "item"
+                                        title: "D\u00e9couvrir questsadditions-1.18.2-1.4.2"
+                                        icon: {
+                                                id: "questsadditions:lootcrate_block"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "questsadditions:lootcrate_block"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "9A5B719EBD5E4B50AE9E737A42D1C021"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 28.0d
+                        y: 0.0d
+                        id: "8D388DBED81943BA8045ABE1428871B0"
+                        tasks: [
+                                {
+                                        id: "1BD6D73C74614F6A892CCB3F90CD71CC"
+                                        type: "item"
+                                        title: "D\u00e9couvrir skyzeradventure-1.0"
+                                        icon: {
+                                                id: "changedminecraft:acacia_boat"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "changedminecraft:acacia_boat"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "85C4114B6725463989932A044CE18446"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 28.0d
+                        y: 2.0d
+                        id: "6A0E7F52AA8242DB96BF8C32EEDA5F22"
+                        tasks: [
+                                {
+                                        id: "FC3EC42D00BB469C8F90E35FD6A3122B"
+                                        type: "item"
+                                        title: "Approfondir skyzeradventure-1.0"
+                                        icon: {
+                                                id: "changedminecraft:acacia_button"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "changedminecraft:acacia_button"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "E80D9E749D9A4593BA30B8CCCCDA7690"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "8D388DBED81943BA8045ABE1428871B0"
+                        ]
+                },
+                {
+                        x: 28.0d
+                        y: 4.0d
+                        id: "3CD55D120AD54CDBA8F59130BA981A84"
+                        tasks: [
+                                {
+                                        id: "38AC46ACEA0B492488309614BFA19DC2"
+                                        type: "item"
+                                        title: "Ma\u00eetriser skyzeradventure-1.0"
+                                        icon: {
+                                                id: "changedminecraft:acacia_door"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "changedminecraft:acacia_door"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "04C40F53BE7046FA86A7D5FDECDB77CC"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "6A0E7F52AA8242DB96BF8C32EEDA5F22"
+                        ]
+                },
+                {
+                        x: 32.0d
+                        y: 0.0d
+                        id: "05A9F4A311F24EDDB213FD5395E83303"
+                        tasks: [
+                                {
+                                        id: "51BBE55705AB47CAAFCFB2868F7EE1C3"
+                                        type: "item"
+                                        title: "D\u00e9couvrir stalwart-dungeons-1.18.2-1.2.8"
+                                        icon: {
+                                                id: "stalwart_dungeons:ancient_fire"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "stalwart_dungeons:ancient_fire"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "E4A8B9735DC64F189F4B287FEB0615CD"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 32.0d
+                        y: 2.0d
+                        id: "B9BD2D1A56E348609B7F090665D45BA0"
+                        tasks: [
+                                {
+                                        id: "6742A8A9AA194477873FE80420A8AD5B"
+                                        type: "item"
+                                        title: "Approfondir stalwart-dungeons-1.18.2-1.2.8"
+                                        icon: {
+                                                id: "stalwart_dungeons:awful_crystal"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "stalwart_dungeons:awful_crystal"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "777C1C11E4D1470391570716A5FFECC1"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "05A9F4A311F24EDDB213FD5395E83303"
+                        ]
+                },
+                {
+                        x: 32.0d
+                        y: 4.0d
+                        id: "96D6B9878CE3474F9842CBE9B2EF300D"
+                        tasks: [
+                                {
+                                        id: "C9BA31C385914915AFD4D2B4CF4DBFFC"
+                                        type: "item"
+                                        title: "Ma\u00eetriser stalwart-dungeons-1.18.2-1.2.8"
+                                        icon: {
+                                                id: "stalwart_dungeons:awful_dagger"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "stalwart_dungeons:awful_dagger"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "58B7646E0803416DA8428342901DF138"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "B9BD2D1A56E348609B7F090665D45BA0"
+                        ]
+                }
+        ]
+}

--- a/Survie/minecraft/config/ftbquests/quests/chapters/mods_magic_gen.snbt
+++ b/Survie/minecraft/config/ftbquests/quests/chapters/mods_magic_gen.snbt
@@ -1,0 +1,450 @@
+{
+        id: "7128384B1E584721901847C71B8F236F"
+        group: ""
+        order_index: 2
+        filename: "mods_magic_gen"
+        title: "Magie"
+        icon: {
+                id: "minecraft:enchanted_book"
+                Count: 1b
+        }
+        default_quest_shape: ""
+        default_hide_dependency_lines: false
+        quests: [
+                {
+                        x: 0.0d
+                        y: 0.0d
+                        id: "E05454F490ED4548B937F125906327FF"
+                        tasks: [
+                                {
+                                        id: "2970910C00F843A7947ACBB24BBBB33B"
+                                        type: "item"
+                                        title: "D\u00e9couvrir Apotheosis-1.18.2-5.8.1"
+                                        icon: {
+                                                id: "apotheosis:ancient_material"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "apotheosis:ancient_material"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "C1303E71B9B74566837C7A50A3FCC1CD"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 0.0d
+                        y: 2.0d
+                        id: "C669F9AEC15243F5A03639CE871400B4"
+                        tasks: [
+                                {
+                                        id: "BC94BDDA98CB4FBD95546BB5CF0E8EF6"
+                                        type: "item"
+                                        title: "Approfondir Apotheosis-1.18.2-5.8.1"
+                                        icon: {
+                                                id: "apotheosis:beeshelf"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "apotheosis:beeshelf"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "F240F1EA50D641759A770CB5911AA389"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "E05454F490ED4548B937F125906327FF"
+                        ]
+                },
+                {
+                        x: 0.0d
+                        y: 4.0d
+                        id: "2C24F134DC8844CD9B9341A39A94993C"
+                        tasks: [
+                                {
+                                        id: "55093C42332B40809E0A219CACB103AC"
+                                        type: "item"
+                                        title: "Ma\u00eetriser Apotheosis-1.18.2-5.8.1"
+                                        icon: {
+                                                id: "apotheosis:blazing_hellshelf"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "apotheosis:blazing_hellshelf"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "D648C72A82C94E70BDA133B8B1E2EE4A"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "C669F9AEC15243F5A03639CE871400B4"
+                        ]
+                },
+                {
+                        x: 4.0d
+                        y: 0.0d
+                        id: "5CB72B447B224251AE999BE9CB74C969"
+                        tasks: [
+                                {
+                                        id: "E3263A25319D425CB1506185F7A81936"
+                                        type: "item"
+                                        title: "D\u00e9couvrir MysticalAgradditions-1.18.2-5.1.4"
+                                        icon: {
+                                                id: "mysticalagradditions:awakened_draconium_crux"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "mysticalagradditions:awakened_draconium_crux"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "FABD890CD150408E89FF4345EED784E7"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 4.0d
+                        y: 2.0d
+                        id: "1DE2474871654E45B689596A5CE3B36C"
+                        tasks: [
+                                {
+                                        id: "6D7B01E93C4B4664AEE104DF2F9FD789"
+                                        type: "item"
+                                        title: "Approfondir MysticalAgradditions-1.18.2-5.1.4"
+                                        icon: {
+                                                id: "mysticalagradditions:creative_essence"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "mysticalagradditions:creative_essence"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "62854DB69B6F4F7581593951F1A46DBB"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "5CB72B447B224251AE999BE9CB74C969"
+                        ]
+                },
+                {
+                        x: 4.0d
+                        y: 4.0d
+                        id: "A8BCA535C6CE4C389318E80A80EEBF4F"
+                        tasks: [
+                                {
+                                        id: "5C87233BDF32410398A7E381BA148548"
+                                        type: "item"
+                                        title: "Ma\u00eetriser MysticalAgradditions-1.18.2-5.1.4"
+                                        icon: {
+                                                id: "mysticalagradditions:dragon_egg_chunk"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "mysticalagradditions:dragon_egg_chunk"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "66EE97CF048D4C03826EF1D524C31A55"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "1DE2474871654E45B689596A5CE3B36C"
+                        ]
+                },
+                {
+                        x: 8.0d
+                        y: 0.0d
+                        id: "38ECEF55CD7848AFB668924749FF3137"
+                        tasks: [
+                                {
+                                        id: "70369B3B2CA84B78AF03F28BB15802FF"
+                                        type: "item"
+                                        title: "D\u00e9couvrir MysticalAgriculture-1.18.2-5.1.5"
+                                        icon: {
+                                                id: "mysticalagriculture:absorption_i_augment"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "mysticalagriculture:absorption_i_augment"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "E432A8CDDA844DE0B834B167E699F6BB"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 8.0d
+                        y: 2.0d
+                        id: "9FC275E4DD2145569B3A377B10FCD720"
+                        tasks: [
+                                {
+                                        id: "249EA1A5314545BDA3E67642F80DD504"
+                                        type: "item"
+                                        title: "Approfondir MysticalAgriculture-1.18.2-5.1.5"
+                                        icon: {
+                                                id: "mysticalagriculture:absorption_ii_augment"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "mysticalagriculture:absorption_ii_augment"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "2E5B56596E104CEAB4AADAB307271342"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "38ECEF55CD7848AFB668924749FF3137"
+                        ]
+                },
+                {
+                        x: 8.0d
+                        y: 4.0d
+                        id: "4197A329968B4C74857167F892E63C42"
+                        tasks: [
+                                {
+                                        id: "8C4F141F7FD446DA9B6E6C6F02359F04"
+                                        type: "item"
+                                        title: "Ma\u00eetriser MysticalAgriculture-1.18.2-5.1.5"
+                                        icon: {
+                                                id: "mysticalagriculture:absorption_iii_augment"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "mysticalagriculture:absorption_iii_augment"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "926B56951A3B490FB93445AD4C98400E"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "9FC275E4DD2145569B3A377B10FCD720"
+                        ]
+                },
+                {
+                        x: 12.0d
+                        y: 0.0d
+                        id: "36BC09E8F4F94EBEBF5BD055AD418652"
+                        tasks: [
+                                {
+                                        id: "19DB9F43017D47308AF36B58752FCAFF"
+                                        type: "item"
+                                        title: "D\u00e9couvrir ars_nouveau-1.18.2-2.9.0"
+                                        icon: {
+                                                id: "ars_nouveau:ab_alternating"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "ars_nouveau:ab_alternating"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "D305350612024FF1AC791BB82413DB89"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 12.0d
+                        y: 2.0d
+                        id: "670FF8445B604264AA8C9D4F2B1A2D47"
+                        tasks: [
+                                {
+                                        id: "4CBFBD5A7F74419CA5A69A170FBBFC53"
+                                        type: "item"
+                                        title: "Approfondir ars_nouveau-1.18.2-2.9.0"
+                                        icon: {
+                                                id: "ars_nouveau:ab_ashlar"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "ars_nouveau:ab_ashlar"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "246955D609824663A456DBF7B0B77861"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "36BC09E8F4F94EBEBF5BD055AD418652"
+                        ]
+                },
+                {
+                        x: 12.0d
+                        y: 4.0d
+                        id: "69B69E52D7594CDBA1EC40F4D75A6CF1"
+                        tasks: [
+                                {
+                                        id: "65F283BA9B3F4F688697323271463F45"
+                                        type: "item"
+                                        title: "Ma\u00eetriser ars_nouveau-1.18.2-2.9.0"
+                                        icon: {
+                                                id: "ars_nouveau:ab_basket"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "ars_nouveau:ab_basket"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "DFF10CA74FA646059720BA5290FF2BC6"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "670FF8445B604264AA8C9D4F2B1A2D47"
+                        ]
+                },
+                {
+                        x: 16.0d
+                        y: 0.0d
+                        id: "78ED97B6093D41A3ADD7923EC759AF0B"
+                        tasks: [
+                                {
+                                        id: "0841BD6041414D5DB31B30FF6FD1C199"
+                                        type: "item"
+                                        title: "D\u00e9couvrir marbledsarsenal-1.18.2-2.1.1"
+                                        icon: {
+                                                id: "marbledsarsenal:armor_plate"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "marbledsarsenal:armor_plate"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "E2733D5D086C4B9ABB72549E640E52A5"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 16.0d
+                        y: 2.0d
+                        id: "5938465402174C4CA735A07DE5699EAB"
+                        tasks: [
+                                {
+                                        id: "A74F9EF3406B4A5E9D4788C37B620040"
+                                        type: "item"
+                                        title: "Approfondir marbledsarsenal-1.18.2-2.1.1"
+                                        icon: {
+                                                id: "marbledsarsenal:barbed_baseball_bat"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "marbledsarsenal:barbed_baseball_bat"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "E17E3667C90D4BA9955CB4A8BF6E1E69"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "78ED97B6093D41A3ADD7923EC759AF0B"
+                        ]
+                },
+                {
+                        x: 16.0d
+                        y: 4.0d
+                        id: "0DB1BFCAC95D4D35ADAB896890A844D9"
+                        tasks: [
+                                {
+                                        id: "25B7BC397EAD441EAF0F8C0C4C178D64"
+                                        type: "item"
+                                        title: "Ma\u00eetriser marbledsarsenal-1.18.2-2.1.1"
+                                        icon: {
+                                                id: "marbledsarsenal:baseball_bat"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "marbledsarsenal:baseball_bat"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "A43C1775CC6E42C3B0282ED02C499F06"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "5938465402174C4CA735A07DE5699EAB"
+                        ]
+                }
+        ]
+}

--- a/Survie/minecraft/config/ftbquests/quests/chapters/mods_other_gen.snbt
+++ b/Survie/minecraft/config/ftbquests/quests/chapters/mods_other_gen.snbt
@@ -1,0 +1,8004 @@
+{
+        id: "579CFC4B8D9A45D487268B56AB17B1DC"
+        group: ""
+        order_index: 5
+        filename: "mods_other_gen"
+        title: "Divers"
+        icon: {
+                id: "minecraft:book"
+                Count: 1b
+        }
+        default_quest_shape: ""
+        default_hide_dependency_lines: false
+        quests: [
+                {
+                        x: 0.0d
+                        y: 0.0d
+                        id: "AE94F4B3552A464D977046CA9C1C9019"
+                        tasks: [
+                                {
+                                        id: "D51716B209554696ABB7308380CA487C"
+                                        type: "item"
+                                        title: "D\u00e9couvrir AmpereCraft 0.3 Forge 1.18"
+                                        icon: {
+                                                id: "ampere_craft:battery"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "ampere_craft:battery"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "2FA48753B6D54A9FB5E227192550FA6E"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 0.0d
+                        y: 2.0d
+                        id: "A5E2758956C24718BD83F865F1601F06"
+                        tasks: [
+                                {
+                                        id: "289F23E476EE4BD7915015932D8F5367"
+                                        type: "item"
+                                        title: "Approfondir AmpereCraft 0.3 Forge 1.18"
+                                        icon: {
+                                                id: "ampere_craft:batterycell"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "ampere_craft:batterycell"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "533F8F329FF4478DBF77B4772AB65D1A"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "AE94F4B3552A464D977046CA9C1C9019"
+                        ]
+                },
+                {
+                        x: 0.0d
+                        y: 4.0d
+                        id: "7FE8383E6AE340CB97E3185D26315D42"
+                        tasks: [
+                                {
+                                        id: "9652C7FA286F4C77A48B50CE002A4A85"
+                                        type: "item"
+                                        title: "Ma\u00eetriser AmpereCraft 0.3 Forge 1.18"
+                                        icon: {
+                                                id: "ampere_craft:batterycelldeluxe"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "ampere_craft:batterycelldeluxe"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "6A3C98DE1B19432FA3143489085601A5"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "A5E2758956C24718BD83F865F1601F06"
+                        ]
+                },
+                {
+                        x: 4.0d
+                        y: 0.0d
+                        id: "D4E3B52355E24ABDAE4D2B0C78730510"
+                        tasks: [
+                                {
+                                        id: "392C4AF7D106408FB72BD3E46CF5FA5A"
+                                        type: "item"
+                                        title: "D\u00e9couvrir Block_Swapper-1.18-1.1"
+                                        icon: {
+                                                id: "blockswapper:copper_block_swapper"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "blockswapper:copper_block_swapper"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "11702136ECE94CA9A9C9111EDDD21A84"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 4.0d
+                        y: 2.0d
+                        id: "BE4B88003F994F538905E31DA3E5C052"
+                        tasks: [
+                                {
+                                        id: "D3CB276B4EB1497B819AD539E4F0476F"
+                                        type: "item"
+                                        title: "Approfondir Block_Swapper-1.18-1.1"
+                                        icon: {
+                                                id: "blockswapper:diamond_block_swapper"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "blockswapper:diamond_block_swapper"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "F51E58F35EDA4745BCAE613998417384"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "D4E3B52355E24ABDAE4D2B0C78730510"
+                        ]
+                },
+                {
+                        x: 8.0d
+                        y: 0.0d
+                        id: "BACBB46AADFB4727BCB3C2D76EB76190"
+                        tasks: [
+                                {
+                                        id: "A0DD9721FF3644E09FC5DE8FEA2B5154"
+                                        type: "item"
+                                        title: "D\u00e9couvrir BuildPasteMod-1.18v1.8.3.1"
+                                        icon: {
+                                                id: "buildpaste:position_selector"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "buildpaste:position_selector"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "EB241106667247B0B936FF7C5B208ECC"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 8.0d
+                        y: 2.0d
+                        id: "393B753093DC4DE6971FB7E392E211CD"
+                        tasks: [
+                                {
+                                        id: "E7FE9F81B5F24B96A93C0FE562825F99"
+                                        type: "item"
+                                        title: "Approfondir BuildPasteMod-1.18v1.8.3.1"
+                                        icon: {
+                                                id: "buildpaste:structure_builder"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "buildpaste:structure_builder"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "BC7C613A0EDA4B3CB67D454D9C6FBA39"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "BACBB46AADFB4727BCB3C2D76EB76190"
+                        ]
+                },
+                {
+                        x: 12.0d
+                        y: 0.0d
+                        id: "529AF95E3E9C4E4883762029753D77FA"
+                        tasks: [
+                                {
+                                        id: "A1818EEE220A4BB7A98E591536EFBC1A"
+                                        type: "item"
+                                        title: "D\u00e9couvrir BuildersDelight-1.18.2-v.1.0"
+                                        icon: {
+                                                id: "buildersdelight:acacia_chair_1"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "buildersdelight:acacia_chair_1"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "9ACCBB9BDD8341658806286E46003EB4"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 12.0d
+                        y: 2.0d
+                        id: "D084562C80B8488DA075D821DC186550"
+                        tasks: [
+                                {
+                                        id: "B07EC63961114FA089DEB81863968145"
+                                        type: "item"
+                                        title: "Approfondir BuildersDelight-1.18.2-v.1.0"
+                                        icon: {
+                                                id: "buildersdelight:acacia_chair_2"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "buildersdelight:acacia_chair_2"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "23B17C2B53D64F1D9ADB98636BFDE6E9"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "529AF95E3E9C4E4883762029753D77FA"
+                        ]
+                },
+                {
+                        x: 12.0d
+                        y: 4.0d
+                        id: "59284117D74140FF944EC0437B7F0C91"
+                        tasks: [
+                                {
+                                        id: "9F51D605D8D049709B2A18C25F32E291"
+                                        type: "item"
+                                        title: "Ma\u00eetriser BuildersDelight-1.18.2-v.1.0"
+                                        icon: {
+                                                id: "buildersdelight:acacia_frame_1"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "buildersdelight:acacia_frame_1"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "25BB8E1E29604D0383CE4C86D171BFB6"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "D084562C80B8488DA075D821DC186550"
+                        ]
+                },
+                {
+                        x: 16.0d
+                        y: 0.0d
+                        id: "083BD885361B449882227EC96BE26F06"
+                        tasks: [
+                                {
+                                        id: "463E29CFDF2D462CBB6BE50F70078EC1"
+                                        type: "item"
+                                        title: "D\u00e9couvrir Citymod-Release-0.1.6.2-1.18.2"
+                                        icon: {
+                                                id: "citymod:air_conditioning"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "citymod:air_conditioning"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "5389AE86229749BF81D9B5E2CE44C7D8"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 16.0d
+                        y: 2.0d
+                        id: "30B78CAFECC545A2B96DC9C24DD551E6"
+                        tasks: [
+                                {
+                                        id: "4798B9402B42466F837494872BA3433A"
+                                        type: "item"
+                                        title: "Approfondir Citymod-Release-0.1.6.2-1.18.2"
+                                        icon: {
+                                                id: "citymod:air_conditioning_external_unit"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "citymod:air_conditioning_external_unit"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "E4F1441B7CAA4857AED313E9F9DFA2F5"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "083BD885361B449882227EC96BE26F06"
+                        ]
+                },
+                {
+                        x: 16.0d
+                        y: 4.0d
+                        id: "61A83C63AA1F4D9DB7D40FE9DECF7858"
+                        tasks: [
+                                {
+                                        id: "2E26417E7F4F46D49A29F7F8665D2A94"
+                                        type: "item"
+                                        title: "Ma\u00eetriser Citymod-Release-0.1.6.2-1.18.2"
+                                        icon: {
+                                                id: "citymod:barrier_gate_down"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "citymod:barrier_gate_down"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "EE4B7A91D86A44FE8F41429578BDEBD0"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "30B78CAFECC545A2B96DC9C24DD551E6"
+                        ]
+                },
+                {
+                        x: 20.0d
+                        y: 0.0d
+                        id: "2E5C4E40024A4CA8BF8F50E2DA4D254F"
+                        tasks: [
+                                {
+                                        id: "F523215D21AA4CAE8320BF82B7D6BD69"
+                                        type: "item"
+                                        title: "D\u00e9couvrir CompactVoidMiners-R1.18.2-1.20"
+                                        icon: {
+                                                id: "compactvoidminers:blank_filter"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "compactvoidminers:blank_filter"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "9423DCFE1C924D26BA807395ABA27CFD"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 20.0d
+                        y: 2.0d
+                        id: "FDAEF1548C4E43C19FA84C8C5834583B"
+                        tasks: [
+                                {
+                                        id: "DE42351D736F45C99D21DA4F08A5BFF8"
+                                        type: "item"
+                                        title: "Approfondir CompactVoidMiners-R1.18.2-1.20"
+                                        icon: {
+                                                id: "compactvoidminers:tag_filter"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "compactvoidminers:tag_filter"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "726B899D6FDE485F9B6C375CCE7D5BE7"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "2E5C4E40024A4CA8BF8F50E2DA4D254F"
+                        ]
+                },
+                {
+                        x: 20.0d
+                        y: 4.0d
+                        id: "73B001269A1B40F2A0042B54DA94BFDD"
+                        tasks: [
+                                {
+                                        id: "B321154A0689485BA33632D02B065462"
+                                        type: "item"
+                                        title: "Ma\u00eetriser CompactVoidMiners-R1.18.2-1.20"
+                                        icon: {
+                                                id: "compactvoidminers:tag_filter_crop"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "compactvoidminers:tag_filter_crop"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "78696A25D0094DDF9DE67D20DD4C6F3F"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "FDAEF1548C4E43C19FA84C8C5834583B"
+                        ]
+                },
+                {
+                        x: 24.0d
+                        y: 0.0d
+                        id: "D28816A72D7949BAA0B77C7BD52AE7AD"
+                        tasks: [
+                                {
+                                        id: "DB6511376A6F4F4088D6459EF94942D0"
+                                        type: "item"
+                                        title: "D\u00e9couvrir Cyclic-1.18.2-1.8.1"
+                                        icon: {
+                                                id: "cyclic:altar_destruction"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "cyclic:altar_destruction"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "E19077F1519A40C4A1173A7285812649"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 24.0d
+                        y: 2.0d
+                        id: "03BF163EDF314BD19C1EFC9C9A14CD4C"
+                        tasks: [
+                                {
+                                        id: "63431D8CF28E4BB38201B62E66D08054"
+                                        type: "item"
+                                        title: "Approfondir Cyclic-1.18.2-1.8.1"
+                                        icon: {
+                                                id: "cyclic:amethyst_axe"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "cyclic:amethyst_axe"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "6375D3EF479A417488AD15F116EB24E6"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "D28816A72D7949BAA0B77C7BD52AE7AD"
+                        ]
+                },
+                {
+                        x: 24.0d
+                        y: 4.0d
+                        id: "1F9FF5B66A7144A5892C80C75C29880C"
+                        tasks: [
+                                {
+                                        id: "B2F50663C0054D64A61347947112823F"
+                                        type: "item"
+                                        title: "Ma\u00eetriser Cyclic-1.18.2-1.8.1"
+                                        icon: {
+                                                id: "cyclic:amethyst_hoe"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "cyclic:amethyst_hoe"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "66757DBEB2004AB9A5DDFF1F1F1C46BA"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "03BF163EDF314BD19C1EFC9C9A14CD4C"
+                        ]
+                },
+                {
+                        x: 28.0d
+                        y: 0.0d
+                        id: "28A0EB616DAD4029A0A6BA1EA2466227"
+                        tasks: [
+                                {
+                                        id: "BE93255E641A441CB5F1CD8D9FF620F9"
+                                        type: "item"
+                                        title: "D\u00e9couvrir DarkUtilities-Forge-1.18.2-10.1.7"
+                                        icon: {
+                                                id: "darkutils:alert_plate"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "darkutils:alert_plate"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "72A9BE0A3B554C43851806F26C6D5E87"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 28.0d
+                        y: 2.0d
+                        id: "E8538566224547049176D1574544DDF6"
+                        tasks: [
+                                {
+                                        id: "01F7AFD4E14A41DBBA5A7607BC7640AB"
+                                        type: "item"
+                                        title: "Approfondir DarkUtilities-Forge-1.18.2-10.1.7"
+                                        icon: {
+                                                id: "darkutils:blank_plate"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "darkutils:blank_plate"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "B453096814934605A3B83D60F6F6C570"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "28A0EB616DAD4029A0A6BA1EA2466227"
+                        ]
+                },
+                {
+                        x: 28.0d
+                        y: 4.0d
+                        id: "7483F4B484F741DA96B6722147889421"
+                        tasks: [
+                                {
+                                        id: "5C949A407F364400B9B66DBCBFAF5721"
+                                        type: "item"
+                                        title: "Ma\u00eetriser DarkUtilities-Forge-1.18.2-10.1.7"
+                                        icon: {
+                                                id: "darkutils:charm_experience"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "darkutils:charm_experience"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "C053DFD9C916406CBC0A5A63BCB29734"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "E8538566224547049176D1574544DDF6"
+                        ]
+                },
+                {
+                        x: 32.0d
+                        y: 0.0d
+                        id: "6980B1895754401CA77FE396136B823E"
+                        tasks: [
+                                {
+                                        id: "378993E7C541480E99377083B4759AAB"
+                                        type: "item"
+                                        title: "D\u00e9couvrir DisenchantmentEditTable-1.18-1.0.9"
+                                        icon: {
+                                                id: "editenchanting:enchantment_edit_table"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "editenchanting:enchantment_edit_table"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "5353D0A5AFEE45A1B17552B024399459"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 36.0d
+                        y: 0.0d
+                        id: "4F1A358399E441BE87C63E12247123DD"
+                        tasks: [
+                                {
+                                        id: "04B51F9C0F52466EB313C9F394787FED"
+                                        type: "item"
+                                        title: "D\u00e9couvrir Draconic-Evolution-1.18.2-3.0.31.531-universal"
+                                        icon: {
+                                                id: "draconicevolution:advanced_dislocator"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "draconicevolution:advanced_dislocator"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "D9E82BBBFA46439DA3E265D2FF95F091"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 36.0d
+                        y: 2.0d
+                        id: "2D211B73068343E6A00BC77C8EFE742E"
+                        tasks: [
+                                {
+                                        id: "5B3399427BB04788977BF545FDA0D89C"
+                                        type: "item"
+                                        title: "Approfondir Draconic-Evolution-1.18.2-3.0.31.531-universal"
+                                        icon: {
+                                                id: "draconicevolution:advanced_magnet"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "draconicevolution:advanced_magnet"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "B11E68C8C3FC4406BC1E54F08D03CE9C"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "4F1A358399E441BE87C63E12247123DD"
+                        ]
+                },
+                {
+                        x: 36.0d
+                        y: 4.0d
+                        id: "9CD41B31B994485C9A4679674CCDDD3E"
+                        tasks: [
+                                {
+                                        id: "8991A113C3D1415F8816A958D861BCF1"
+                                        type: "item"
+                                        title: "Ma\u00eetriser Draconic-Evolution-1.18.2-3.0.31.531-universal"
+                                        icon: {
+                                                id: "draconicevolution:awakened_core"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "draconicevolution:awakened_core"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "C8AFF0F3C53E411D837D061E4EABE120"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "2D211B73068343E6A00BC77C8EFE742E"
+                        ]
+                },
+                {
+                        x: 40.0d
+                        y: 0.0d
+                        id: "810C07853FFD4438B5F83FADC8AC54E7"
+                        tasks: [
+                                {
+                                        id: "E63F2A587D464BF1A20620713C07822C"
+                                        type: "item"
+                                        title: "D\u00e9couvrir EnchantingInfuser-v3.3.3-1.18.2-Forge"
+                                        icon: {
+                                                id: "enchantinginfuser:advanced_enchanting_infuser"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "enchantinginfuser:advanced_enchanting_infuser"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "4B73026B331A4D6A8F4176686ECA3FB6"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 40.0d
+                        y: 2.0d
+                        id: "09C28255504546DD89181D3F1EA04E39"
+                        tasks: [
+                                {
+                                        id: "D6B6D898815D41B49F087D7728136A3E"
+                                        type: "item"
+                                        title: "Approfondir EnchantingInfuser-v3.3.3-1.18.2-Forge"
+                                        icon: {
+                                                id: "enchantinginfuser:enchanting_infuser"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "enchantinginfuser:enchanting_infuser"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "B12CEE616734471B928BD92AB3F13233"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "810C07853FFD4438B5F83FADC8AC54E7"
+                        ]
+                },
+                {
+                        x: 44.0d
+                        y: 0.0d
+                        id: "0351C753B0F44FA28E99096C5C1F8327"
+                        tasks: [
+                                {
+                                        id: "E03B3D23830A452596CFE57C3F9AB3F1"
+                                        type: "item"
+                                        title: "D\u00e9couvrir Exchangers-1.18.2-3.3.1"
+                                        icon: {
+                                                id: "exchangers:advanced_exchanger"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "exchangers:advanced_exchanger"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "65BC2BC76FD94969B6DCC085D7716E9C"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 44.0d
+                        y: 2.0d
+                        id: "832A53C5297843429195A6862F132905"
+                        tasks: [
+                                {
+                                        id: "21003BABBE8947CBBF2F66265CD45390"
+                                        type: "item"
+                                        title: "Approfondir Exchangers-1.18.2-3.3.1"
+                                        icon: {
+                                                id: "exchangers:amethyst_exchanger"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "exchangers:amethyst_exchanger"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "69973E894C8F40E6B53FAAFEFDCE5DCD"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "0351C753B0F44FA28E99096C5C1F8327"
+                        ]
+                },
+                {
+                        x: 44.0d
+                        y: 4.0d
+                        id: "8D51657FC8DB45C3B363905F54289AFC"
+                        tasks: [
+                                {
+                                        id: "3D9A616F3B2E4341AC01D6387A814E35"
+                                        type: "item"
+                                        title: "Ma\u00eetriser Exchangers-1.18.2-3.3.1"
+                                        icon: {
+                                                id: "exchangers:basic_exchanger"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "exchangers:basic_exchanger"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "F1046780426148C8A18EBD6E40EBD7E2"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "832A53C5297843429195A6862F132905"
+                        ]
+                },
+                {
+                        x: 48.0d
+                        y: 0.0d
+                        id: "A5FC146C185B4E50A06238DD2895031A"
+                        tasks: [
+                                {
+                                        id: "4689003EF9674764AC988D2C3DE97FAE"
+                                        type: "item"
+                                        title: "D\u00e9couvrir ExtremeReactors2-1.18.2-2.0.71"
+                                        icon: {
+                                                id: "bigreactors:anglesite_crystal"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "bigreactors:anglesite_crystal"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "56BC7785B0C447E6863C48DC6BEDEFA5"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 48.0d
+                        y: 2.0d
+                        id: "350E135975D24CF58426392498D6BE25"
+                        tasks: [
+                                {
+                                        id: "B41DAC6D433243EFAC8471D4A020070A"
+                                        type: "item"
+                                        title: "Approfondir ExtremeReactors2-1.18.2-2.0.71"
+                                        icon: {
+                                                id: "bigreactors:anglesite_ore"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "bigreactors:anglesite_ore"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "5F43CB44AB9E404997AB0659DA2535FF"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "A5FC146C185B4E50A06238DD2895031A"
+                        ]
+                },
+                {
+                        x: 48.0d
+                        y: 4.0d
+                        id: "7ED91CA316DB4C709C40EF0FFF7A3B41"
+                        tasks: [
+                                {
+                                        id: "A076328138604C61B8E530166AA4BF38"
+                                        type: "item"
+                                        title: "Ma\u00eetriser ExtremeReactors2-1.18.2-2.0.71"
+                                        icon: {
+                                                id: "bigreactors:basic_reactorcasing"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "bigreactors:basic_reactorcasing"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "3D8CD5C08C544FD099B2C017758CBB09"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "350E135975D24CF58426392498D6BE25"
+                        ]
+                },
+                {
+                        x: 52.0d
+                        y: 0.0d
+                        id: "E24E18BF67514609B9F13A9B2D8A737A"
+                        tasks: [
+                                {
+                                        id: "DDDF075713DC41C09C09AD77401C2850"
+                                        type: "item"
+                                        title: "D\u00e9couvrir FluxNetworks-1.18.2-7.0.9.15"
+                                        icon: {
+                                                id: "fluxnetworks:admin_configurator"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "fluxnetworks:admin_configurator"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "299A4F693875407AB73DF105CEE9BC63"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 52.0d
+                        y: 2.0d
+                        id: "C67DF2BFE74940BA9A7C903E39AA08A1"
+                        tasks: [
+                                {
+                                        id: "BF644E0BA2DB4A2E95E08981406E1072"
+                                        type: "item"
+                                        title: "Approfondir FluxNetworks-1.18.2-7.0.9.15"
+                                        icon: {
+                                                id: "fluxnetworks:basic_flux_storage"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "fluxnetworks:basic_flux_storage"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "2222A829DD7F48438B82A7FB001E67F1"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "E24E18BF67514609B9F13A9B2D8A737A"
+                        ]
+                },
+                {
+                        x: 52.0d
+                        y: 4.0d
+                        id: "0378F5C7A93041B6821BF7A14142BDC1"
+                        tasks: [
+                                {
+                                        id: "AA0C4B88D6ED47CAB41951099C0D1AA5"
+                                        type: "item"
+                                        title: "Ma\u00eetriser FluxNetworks-1.18.2-7.0.9.15"
+                                        icon: {
+                                                id: "fluxnetworks:flux_block"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "fluxnetworks:flux_block"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "F90BF083B71E4ACBA8CAE169E471E896"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "C67DF2BFE74940BA9A7C903E39AA08A1"
+                        ]
+                },
+                {
+                        x: 56.0d
+                        y: 0.0d
+                        id: "F073D81791A9404280A31EDB11DA2BD3"
+                        tasks: [
+                                {
+                                        id: "F888B29A7F6D4F4EAC857FCF51C19808"
+                                        type: "item"
+                                        title: "D\u00e9couvrir FramedBlocks-5.11.5"
+                                        icon: {
+                                                id: "framedblocks:framed_activator_rail_slope"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "framedblocks:framed_activator_rail_slope"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "87A0B3632A614BE887918821E434C6AA"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 56.0d
+                        y: 2.0d
+                        id: "2B315EE63B254BD2BD6F9C2B26D06D6B"
+                        tasks: [
+                                {
+                                        id: "21D48BC2A55C42BC9CAF4F730B4AB176"
+                                        type: "item"
+                                        title: "Approfondir FramedBlocks-5.11.5"
+                                        icon: {
+                                                id: "framedblocks:framed_bars"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "framedblocks:framed_bars"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "CC5289BC8E4948BA85696F7E192FC2CC"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "F073D81791A9404280A31EDB11DA2BD3"
+                        ]
+                },
+                {
+                        x: 56.0d
+                        y: 4.0d
+                        id: "5FE9A046124848D3898838D3B9166717"
+                        tasks: [
+                                {
+                                        id: "64D905CADF7449588933F1EF44B02FBE"
+                                        type: "item"
+                                        title: "Ma\u00eetriser FramedBlocks-5.11.5"
+                                        icon: {
+                                                id: "framedblocks:framed_blueprint"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "framedblocks:framed_blueprint"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "5D4EC1BD9E124B88BA952C750EE7CB31"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "2B315EE63B254BD2BD6F9C2B26D06D6B"
+                        ]
+                },
+                {
+                        x: 60.0d
+                        y: 0.0d
+                        id: "54B5CA7F463D4B789F9C6C6845CECB04"
+                        tasks: [
+                                {
+                                        id: "64FA5742B5DB47248438869C9C9343B4"
+                                        type: "item"
+                                        title: "D\u00e9couvrir HammerLib-1.18.2-18.2.16"
+                                        icon: {
+                                                id: "hammerlib:test_machine"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "hammerlib:test_machine"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "F72CC7407AEB4719A638DF1019DC4B57"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 60.0d
+                        y: 2.0d
+                        id: "D09DE323F21F4BAC9CDE4F44A9DB6371"
+                        tasks: [
+                                {
+                                        id: "0C671C8DA3224BA6B1D03E25E93BBA7A"
+                                        type: "item"
+                                        title: "Approfondir HammerLib-1.18.2-18.2.16"
+                                        icon: {
+                                                id: "hammerlib:wrench"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "hammerlib:wrench"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "8588973F1C3F4258B9E6722800060C76"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "54B5CA7F463D4B789F9C6C6845CECB04"
+                        ]
+                },
+                {
+                        x: 64.0d
+                        y: 0.0d
+                        id: "BC9B58DD827C4662AE6AFAAD8ACC73BC"
+                        tasks: [
+                                {
+                                        id: "A85F412BFCDD4E429153C13C28CD7F46"
+                                        type: "item"
+                                        title: "D\u00e9couvrir Luxury Furnitures 2.29.0 1.18.2"
+                                        icon: {
+                                                id: "luxuryfurnitures:acindoorunit"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "luxuryfurnitures:acindoorunit"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "457A7B52349E441B84A6AC1EEF6E944C"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 64.0d
+                        y: 2.0d
+                        id: "BC8657CD1FC04DD796E65A781EFC9B3D"
+                        tasks: [
+                                {
+                                        id: "4658B69B122A45EDBA3D94839D6D4CF5"
+                                        type: "item"
+                                        title: "Approfondir Luxury Furnitures 2.29.0 1.18.2"
+                                        icon: {
+                                                id: "luxuryfurnitures:acoutdoorunit"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "luxuryfurnitures:acoutdoorunit"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "559FD03F855B4557A8868C2139108AF7"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "BC9B58DD827C4662AE6AFAAD8ACC73BC"
+                        ]
+                },
+                {
+                        x: 64.0d
+                        y: 4.0d
+                        id: "B1229FD6646D4C9CA93DC6027D7C8941"
+                        tasks: [
+                                {
+                                        id: "673A266FC0834F6B8805BE98E015A6B3"
+                                        type: "item"
+                                        title: "Ma\u00eetriser Luxury Furnitures 2.29.0 1.18.2"
+                                        icon: {
+                                                id: "luxuryfurnitures:airfryer"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "luxuryfurnitures:airfryer"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "BD2D607861D74DDEB843D36CF0B214F1"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "BC8657CD1FC04DD796E65A781EFC9B3D"
+                        ]
+                },
+                {
+                        x: 68.0d
+                        y: 0.0d
+                        id: "06082CAC8EBF4E3EA1EEB61B3B4E569B"
+                        tasks: [
+                                {
+                                        id: "4ABED14F5AAA42EA957EE5B82D19FA8B"
+                                        type: "item"
+                                        title: "D\u00e9couvrir MTR-forge-1.18.2-3.2.2-hotfix-1"
+                                        icon: {
+                                                id: "mtr:airplane_node"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "mtr:airplane_node"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "1F840497BF494A73BFFCDFE70F7A2783"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 68.0d
+                        y: 2.0d
+                        id: "0A47CEC2F2B44B50844EB6667B04F5FD"
+                        tasks: [
+                                {
+                                        id: "5672BC4C9A4545FAB17F75D5739568C5"
+                                        type: "item"
+                                        title: "Approfondir MTR-forge-1.18.2-3.2.2-hotfix-1"
+                                        icon: {
+                                                id: "mtr:apg_door"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "mtr:apg_door"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "265301C11B004B99B596FB8ECDCB1FEF"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "06082CAC8EBF4E3EA1EEB61B3B4E569B"
+                        ]
+                },
+                {
+                        x: 68.0d
+                        y: 4.0d
+                        id: "3590498AE2CD4976ADFAEE86E3DDC155"
+                        tasks: [
+                                {
+                                        id: "D80EDE6DBBE04E9789D22235B1F53A7E"
+                                        type: "item"
+                                        title: "Ma\u00eetriser MTR-forge-1.18.2-3.2.2-hotfix-1"
+                                        icon: {
+                                                id: "mtr:apg_glass"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "mtr:apg_glass"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "A0CA5C73A54D443488CBD2D8FDF01CD0"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "0A47CEC2F2B44B50844EB6667B04F5FD"
+                        ]
+                },
+                {
+                        x: 72.0d
+                        y: 0.0d
+                        id: "7CA900153D754A18AD27F53F5C06C93F"
+                        tasks: [
+                                {
+                                        id: "DAD01ACB343347609BEB38D46A0ADC25"
+                                        type: "item"
+                                        title: "D\u00e9couvrir ModernxlSurvival_1.3.2_v1.18.2"
+                                        icon: {
+                                                id: "modernxl_ii:alabaster"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "modernxl_ii:alabaster"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "AAC681D751164481B087AFCF70E4C532"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 72.0d
+                        y: 2.0d
+                        id: "44F3D1E0A80046A78E1530E892A61F3A"
+                        tasks: [
+                                {
+                                        id: "FC217DB382BA453AA214ED9BDF82062F"
+                                        type: "item"
+                                        title: "Approfondir ModernxlSurvival_1.3.2_v1.18.2"
+                                        icon: {
+                                                id: "modernxl_ii:alabaster_lamp_on"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "modernxl_ii:alabaster_lamp_on"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "74EDDA6D527F49BE9541DBD6C9C6B1E4"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "7CA900153D754A18AD27F53F5C06C93F"
+                        ]
+                },
+                {
+                        x: 72.0d
+                        y: 4.0d
+                        id: "F98F1F08D0E24F9BBA253F2C6B889D37"
+                        tasks: [
+                                {
+                                        id: "E914C714257D47048DE7D7E64368AEBC"
+                                        type: "item"
+                                        title: "Ma\u00eetriser ModernxlSurvival_1.3.2_v1.18.2"
+                                        icon: {
+                                                id: "modernxl_ii:alabaster_lampoff"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "modernxl_ii:alabaster_lampoff"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "0F97288C5B3C43498072F8D45532157D"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "44F3D1E0A80046A78E1530E892A61F3A"
+                        ]
+                },
+                {
+                        x: 76.0d
+                        y: 0.0d
+                        id: "805D97B8AD6144A897672524EDCB097D"
+                        tasks: [
+                                {
+                                        id: "E0E9681730CE446DA0DF1D4BC723FEF0"
+                                        type: "item"
+                                        title: "D\u00e9couvrir NaturesCompass-1.18.2-1.9.7-forge"
+                                        icon: {
+                                                id: "naturescompass:naturescompass"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "naturescompass:naturescompass"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "B169EA3FCFF54F899CCA6ED761E7518B"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 76.0d
+                        y: 2.0d
+                        id: "FB9E8A1CE1E148699D42728C6AECC4C5"
+                        tasks: [
+                                {
+                                        id: "BA42EAF610D747BFB9F011191B38241B"
+                                        type: "item"
+                                        title: "Approfondir NaturesCompass-1.18.2-1.9.7-forge"
+                                        icon: {
+                                                id: "naturescompass:naturescompass_00"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "naturescompass:naturescompass_00"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "A08B97EDB6C84B9880AD79A7FAD0662F"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "805D97B8AD6144A897672524EDCB097D"
+                        ]
+                },
+                {
+                        x: 76.0d
+                        y: 4.0d
+                        id: "5B3D4F0FAA7246BD9FC3568FF0CCA601"
+                        tasks: [
+                                {
+                                        id: "97FE7ED0221240A88A8C4B1A2A6B04B3"
+                                        type: "item"
+                                        title: "Ma\u00eetriser NaturesCompass-1.18.2-1.9.7-forge"
+                                        icon: {
+                                                id: "naturescompass:naturescompass_01"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "naturescompass:naturescompass_01"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "025B8927467F4D91882DFDBE044AB0D9"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "FB9E8A1CE1E148699D42728C6AECC4C5"
+                        ]
+                },
+                {
+                        x: 80.0d
+                        y: 0.0d
+                        id: "E019E6495E9F4936B0216CCD7EAE3652"
+                        tasks: [
+                                {
+                                        id: "A37C8C43865F427D9400AC5CD2A154BF"
+                                        type: "item"
+                                        title: "D\u00e9couvrir OreLibrary-1.18.2-1.0.2"
+                                        icon: {
+                                                id: "orelibrary:copper_ingot"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "orelibrary:copper_ingot"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "1DE6B6E5EA584672884625526418A096"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 80.0d
+                        y: 2.0d
+                        id: "32F711D9AE474DE8844F24970F1F5B2B"
+                        tasks: [
+                                {
+                                        id: "67E8F688842146C2AFA5A33B9CE13EF2"
+                                        type: "item"
+                                        title: "Approfondir OreLibrary-1.18.2-1.0.2"
+                                        icon: {
+                                                id: "orelibrary:copper_nugget"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "orelibrary:copper_nugget"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "7168CADDA9424758922DB9DC4A45CBF3"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "E019E6495E9F4936B0216CCD7EAE3652"
+                        ]
+                },
+                {
+                        x: 80.0d
+                        y: 4.0d
+                        id: "488A1E72F84E49F7993E6E25962CE90F"
+                        tasks: [
+                                {
+                                        id: "AC2D6202A0AA42CE8F0E2F306DEA7149"
+                                        type: "item"
+                                        title: "Ma\u00eetriser OreLibrary-1.18.2-1.0.2"
+                                        icon: {
+                                                id: "orelibrary:copper_ore"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "orelibrary:copper_ore"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "E7E81495388848129EB37CDBB6893A1E"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "32F711D9AE474DE8844F24970F1F5B2B"
+                        ]
+                },
+                {
+                        x: 84.0d
+                        y: 0.0d
+                        id: "76B6E8023E97492283A0C85642C9DA89"
+                        tasks: [
+                                {
+                                        id: "B78955F993EC4A6D9E82AB63940E03B6"
+                                        type: "item"
+                                        title: "D\u00e9couvrir Patchouli-1.18.2-71.1"
+                                        icon: {
+                                                id: "patchouli:book_blue"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "patchouli:book_blue"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "2DCFE0F7965F49368D235B8829EDEB88"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 84.0d
+                        y: 2.0d
+                        id: "1E886852AD8F4FE0BE7AB876AABB64E7"
+                        tasks: [
+                                {
+                                        id: "7C78BFA24E6C428CB255F5E66E41DB89"
+                                        type: "item"
+                                        title: "Approfondir Patchouli-1.18.2-71.1"
+                                        icon: {
+                                                id: "patchouli:book_brown"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "patchouli:book_brown"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "1D26BBFA461147CE9F4771DBB5734B62"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "76B6E8023E97492283A0C85642C9DA89"
+                        ]
+                },
+                {
+                        x: 84.0d
+                        y: 4.0d
+                        id: "867D7358A9FF47B68C34CBD76C820A42"
+                        tasks: [
+                                {
+                                        id: "F487D9AC736F449CB19BCD7D1FB3A53A"
+                                        type: "item"
+                                        title: "Ma\u00eetriser Patchouli-1.18.2-71.1"
+                                        icon: {
+                                                id: "patchouli:book_completion"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "patchouli:book_completion"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "5025C9DA93694B5AB83A8D27E809D16D"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "1E886852AD8F4FE0BE7AB876AABB64E7"
+                        ]
+                },
+                {
+                        x: 88.0d
+                        y: 0.0d
+                        id: "E4647B024DB24BC9906AB15442444EDB"
+                        tasks: [
+                                {
+                                        id: "1FB7746264B84B81B3FF17ED01FECD77"
+                                        type: "item"
+                                        title: "D\u00e9couvrir Quark-3.2-358"
+                                        icon: {
+                                                id: "quark:abacus"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "quark:abacus"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "4CC34428A5814BD38A3230B82AA56AC3"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 88.0d
+                        y: 2.0d
+                        id: "5FDECEE452234577858E1ACFE3E4F805"
+                        tasks: [
+                                {
+                                        id: "3AAB76B0781D48E1A10AAF4E5B58807B"
+                                        type: "item"
+                                        title: "Approfondir Quark-3.2-358"
+                                        icon: {
+                                                id: "quark:abacus_0"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "quark:abacus_0"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "DD81ED0D83624169AB3655C8370FB95E"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "E4647B024DB24BC9906AB15442444EDB"
+                        ]
+                },
+                {
+                        x: 88.0d
+                        y: 4.0d
+                        id: "E19C5AB937A345D5BF731FA5062BC1A0"
+                        tasks: [
+                                {
+                                        id: "C60CA68BBD4042029860BACE27CE0BCB"
+                                        type: "item"
+                                        title: "Ma\u00eetriser Quark-3.2-358"
+                                        icon: {
+                                                id: "quark:abacus_1"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "quark:abacus_1"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "F3E7C56A07774062BFBA46E46C70D5F4"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "5FDECEE452234577858E1ACFE3E4F805"
+                        ]
+                },
+                {
+                        x: 92.0d
+                        y: 0.0d
+                        id: "154EAD9BEF4F4CAA8CD27E962211B61C"
+                        tasks: [
+                                {
+                                        id: "112972D8FC5B4A809D89FD005029EFFE"
+                                        type: "item"
+                                        title: "D\u00e9couvrir SimpleStorageNetwork-1.18.2-1.7.1"
+                                        icon: {
+                                                id: "storagenetwork:builder_remote"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "storagenetwork:builder_remote"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "DCF126CB07B641BC941C6CC0B38C93ED"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 92.0d
+                        y: 2.0d
+                        id: "513DCC6ED9EE4F81804F806BAE4B87CA"
+                        tasks: [
+                                {
+                                        id: "98B5A36B2E4D4D539C08FF321332CC68"
+                                        type: "item"
+                                        title: "Approfondir SimpleStorageNetwork-1.18.2-1.7.1"
+                                        icon: {
+                                                id: "storagenetwork:collector"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "storagenetwork:collector"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "9AD30C9A4DDD48B5944C40A026A48F99"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "154EAD9BEF4F4CAA8CD27E962211B61C"
+                        ]
+                },
+                {
+                        x: 92.0d
+                        y: 4.0d
+                        id: "C17A467B92AA41D0ADBE690EAFC61804"
+                        tasks: [
+                                {
+                                        id: "99EB8E1AF6544BA9BBC6A8E566220DFB"
+                                        type: "item"
+                                        title: "Ma\u00eetriser SimpleStorageNetwork-1.18.2-1.7.1"
+                                        icon: {
+                                                id: "storagenetwork:collector_remote"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "storagenetwork:collector_remote"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "206B785E8EEA4448A1F99A1C73B88857"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "513DCC6ED9EE4F81804F806BAE4B87CA"
+                        ]
+                },
+                {
+                        x: 96.0d
+                        y: 0.0d
+                        id: "D3391A2074EC4D6DAF2E2EE5BA8291A4"
+                        tasks: [
+                                {
+                                        id: "283885C777B841888BCBB843A4C99E85"
+                                        type: "item"
+                                        title: "D\u00e9couvrir Simply Loot Bags-1.18.2"
+                                        icon: {
+                                                id: "simply_loot_bags:common_loot_bag"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "simply_loot_bags:common_loot_bag"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "912C13EB6F6442C297BE1B7E4C66BE34"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 96.0d
+                        y: 2.0d
+                        id: "0FDC587110ED434F94E325A83E12E26C"
+                        tasks: [
+                                {
+                                        id: "457BDC8B29F84EF1BA9166F47221AE93"
+                                        type: "item"
+                                        title: "Approfondir Simply Loot Bags-1.18.2"
+                                        icon: {
+                                                id: "simply_loot_bags:diamond_loot_bag"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "simply_loot_bags:diamond_loot_bag"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "0EA189C17B414B02900CC8563407549F"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "D3391A2074EC4D6DAF2E2EE5BA8291A4"
+                        ]
+                },
+                {
+                        x: 96.0d
+                        y: 4.0d
+                        id: "D714DD4842B8426AB53766733723D68A"
+                        tasks: [
+                                {
+                                        id: "DEE15A2EA5A849448F732F12ECDFCBCD"
+                                        type: "item"
+                                        title: "Ma\u00eetriser Simply Loot Bags-1.18.2"
+                                        icon: {
+                                                id: "simply_loot_bags:diamond_nugget"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "simply_loot_bags:diamond_nugget"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "C468121B8D5349D59DC3004724E3747C"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "0FDC587110ED434F94E325A83E12E26C"
+                        ]
+                },
+                {
+                        x: 100.0d
+                        y: 0.0d
+                        id: "93DD39B00E83442EADCEAD407AD95B27"
+                        tasks: [
+                                {
+                                        id: "35F44394228740479C7F033EA05302B8"
+                                        type: "item"
+                                        title: "D\u00e9couvrir SolarGeneration-1.18.2-4.1.1"
+                                        icon: {
+                                                id: "solargeneration:lapis_shard"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "solargeneration:lapis_shard"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "4AD80C1CA7CC4E43B07ADFB26C32935D"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 100.0d
+                        y: 2.0d
+                        id: "C981D2D8BD6741D692AF662D9DCFE72A"
+                        tasks: [
+                                {
+                                        id: "F0027E02362547D7AFE34D47A96AAF91"
+                                        type: "item"
+                                        title: "Approfondir SolarGeneration-1.18.2-4.1.1"
+                                        icon: {
+                                                id: "solargeneration:photovoltaic_cell"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "solargeneration:photovoltaic_cell"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "AEEA8A4F688C423FBD5E854A365300DA"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "93DD39B00E83442EADCEAD407AD95B27"
+                        ]
+                },
+                {
+                        x: 100.0d
+                        y: 4.0d
+                        id: "C3D90CE0A24444BEBE892342E4050559"
+                        tasks: [
+                                {
+                                        id: "ED5C5D940D7649D898107CB351D2AA37"
+                                        type: "item"
+                                        title: "Ma\u00eetriser SolarGeneration-1.18.2-4.1.1"
+                                        icon: {
+                                                id: "solargeneration:solar_core_advanced"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "solargeneration:solar_core_advanced"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "33358A9B2C894AB1BBEFA52698E0842C"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "C981D2D8BD6741D692AF662D9DCFE72A"
+                        ]
+                },
+                {
+                        x: 104.0d
+                        y: 0.0d
+                        id: "B957FEC8ACE747EF81C2CD3887E0276D"
+                        tasks: [
+                                {
+                                        id: "F0D279E9F13540AFB7779DE8F42EA1FB"
+                                        type: "item"
+                                        title: "D\u00e9couvrir StorageDrawers-1.18.2-10.2.1"
+                                        icon: {
+                                                id: "storagedrawers:acacia_full_drawers_1"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "storagedrawers:acacia_full_drawers_1"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "CB73CE7767854870A1CCB8D50446884A"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 104.0d
+                        y: 2.0d
+                        id: "13F6A4D460254406BF7D6E90DB0781DD"
+                        tasks: [
+                                {
+                                        id: "F4FCCA88D2914D67B444495C5E4BE3B5"
+                                        type: "item"
+                                        title: "Approfondir StorageDrawers-1.18.2-10.2.1"
+                                        icon: {
+                                                id: "storagedrawers:acacia_full_drawers_2"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "storagedrawers:acacia_full_drawers_2"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "AF992AA8ABD848E8A0DC6BCD279D467B"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "B957FEC8ACE747EF81C2CD3887E0276D"
+                        ]
+                },
+                {
+                        x: 104.0d
+                        y: 4.0d
+                        id: "3E5538416387462A902BF481B6E6321D"
+                        tasks: [
+                                {
+                                        id: "0DB3E6ACE8DC4C74B0E87B62AA71831C"
+                                        type: "item"
+                                        title: "Ma\u00eetriser StorageDrawers-1.18.2-10.2.1"
+                                        icon: {
+                                                id: "storagedrawers:acacia_full_drawers_4"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "storagedrawers:acacia_full_drawers_4"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "2F859730B45D43999A8375A26B6A93B5"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "13F6A4D460254406BF7D6E90DB0781DD"
+                        ]
+                },
+                {
+                        x: 108.0d
+                        y: 0.0d
+                        id: "0336DCD8A8804853AB2D74B8BD2506A9"
+                        tasks: [
+                                {
+                                        id: "4FE5473395DA4B018AC6299ECE9AE789"
+                                        type: "item"
+                                        title: "D\u00e9couvrir ZeroCore2-1.18.2-2.1.39"
+                                        icon: {
+                                                id: "zerocore:debugtool"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "zerocore:debugtool"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "13829263496D4AF7B36CF9CEB1A3DD62"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 112.0d
+                        y: 0.0d
+                        id: "E06563359D984022B455AA19A04C9D5F"
+                        tasks: [
+                                {
+                                        id: "2B8FEC4A7BF34AE3AC3254451AE1C5BC"
+                                        type: "item"
+                                        title: "D\u00e9couvrir [1.18.2] SecurityCraft v1.10"
+                                        icon: {
+                                                id: "securitycraft:admin_tool"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "securitycraft:admin_tool"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "4D2966215A104D64B7D8C22B77299AE3"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 112.0d
+                        y: 2.0d
+                        id: "E4A206820B4943D79CB90D56588C26B8"
+                        tasks: [
+                                {
+                                        id: "B7C4964785AF4D67953A4FF4032E772C"
+                                        type: "item"
+                                        title: "Approfondir [1.18.2] SecurityCraft v1.10"
+                                        icon: {
+                                                id: "securitycraft:alarm"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "securitycraft:alarm"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "203796A7AD6D432FA03A77AF9E14A4F6"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "E06563359D984022B455AA19A04C9D5F"
+                        ]
+                },
+                {
+                        x: 112.0d
+                        y: 4.0d
+                        id: "03C22A6D87CF4312B44737F21C97C04F"
+                        tasks: [
+                                {
+                                        id: "9C3ACFF1CEB9441FB6DD754DF1C9E0BC"
+                                        type: "item"
+                                        title: "Ma\u00eetriser [1.18.2] SecurityCraft v1.10"
+                                        icon: {
+                                                id: "securitycraft:ancient_debris_mine"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "securitycraft:ancient_debris_mine"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "81D360ED02EC4991BB0E3B7E1F2EEA6D"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "E4A206820B4943D79CB90D56588C26B8"
+                        ]
+                },
+                {
+                        x: 116.0d
+                        y: 0.0d
+                        id: "D02B3FB8535C4BEFB714F8CCACCC0B12"
+                        tasks: [
+                                {
+                                        id: "603808BA5B2E48B6A0281E5DCC749849"
+                                        type: "item"
+                                        title: "D\u00e9couvrir additionalcolors-1.18.2-2.0.0.0-forge"
+                                        icon: {
+                                                id: "additionalcolors:black_acacia_fence"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "additionalcolors:black_acacia_fence"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "2A9BA4150DD8469B8FFEFC35626C9982"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 116.0d
+                        y: 2.0d
+                        id: "4148C16B5C44431C8919DDA14EC1632C"
+                        tasks: [
+                                {
+                                        id: "BF5B6C3DAE6C46F6B0CB40E3BC6FA279"
+                                        type: "item"
+                                        title: "Approfondir additionalcolors-1.18.2-2.0.0.0-forge"
+                                        icon: {
+                                                id: "additionalcolors:black_acacia_fence_gate"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "additionalcolors:black_acacia_fence_gate"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "51F08C1F27D14DF0976D0BC94DA4170D"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "D02B3FB8535C4BEFB714F8CCACCC0B12"
+                        ]
+                },
+                {
+                        x: 116.0d
+                        y: 4.0d
+                        id: "327CFCE2F1A24EC99D39789135103F96"
+                        tasks: [
+                                {
+                                        id: "AD423BB139F94908B9D3B61634C96DBE"
+                                        type: "item"
+                                        title: "Ma\u00eetriser additionalcolors-1.18.2-2.0.0.0-forge"
+                                        icon: {
+                                                id: "additionalcolors:black_acacia_planks"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "additionalcolors:black_acacia_planks"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "85C1F888C04B4B9881546DCC4F3725C0"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "4148C16B5C44431C8919DDA14EC1632C"
+                        ]
+                },
+                {
+                        x: 120.0d
+                        y: 0.0d
+                        id: "34C6C1087FBE40BEA87028978CB300E7"
+                        tasks: [
+                                {
+                                        id: "86A8D3655C4746D9A355CBB59E7AD1D0"
+                                        type: "item"
+                                        title: "D\u00e9couvrir alexsmobs-1.18.6"
+                                        icon: {
+                                                id: "alexsmobs:acacia_blossom"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "alexsmobs:acacia_blossom"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "04795C7BC2664E949EF225B8650B1F2F"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 120.0d
+                        y: 2.0d
+                        id: "F2143270C8CB42A2A466A8D723189ABA"
+                        tasks: [
+                                {
+                                        id: "FCC220F6E31E4A4BB7F2F0A7CCDA62CC"
+                                        type: "item"
+                                        title: "Approfondir alexsmobs-1.18.6"
+                                        icon: {
+                                                id: "alexsmobs:ambergris"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "alexsmobs:ambergris"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "3FD1E23F774D424580C7D31BAA016123"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "34C6C1087FBE40BEA87028978CB300E7"
+                        ]
+                },
+                {
+                        x: 120.0d
+                        y: 4.0d
+                        id: "4B61065175D04AC18B8EAC4B27F48B01"
+                        tasks: [
+                                {
+                                        id: "3465DB9EE18044C7A62457C0C1BC41ED"
+                                        type: "item"
+                                        title: "Ma\u00eetriser alexsmobs-1.18.6"
+                                        icon: {
+                                                id: "alexsmobs:ancient_dart"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "alexsmobs:ancient_dart"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "ADA6763F138C4DF69DBAF65791A74F91"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "F2143270C8CB42A2A466A8D723189ABA"
+                        ]
+                },
+                {
+                        x: 124.0d
+                        y: 0.0d
+                        id: "5923CE8D199C47D499FD365F1AE12AEB"
+                        tasks: [
+                                {
+                                        id: "5E6C02E1ED1E4E09B4927702FAA9FE02"
+                                        type: "item"
+                                        title: "D\u00e9couvrir allthemodium-1.9.6-1.18.2-40.1.51"
+                                        icon: {
+                                                id: "allthemodium:alloy_axe"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "allthemodium:alloy_axe"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "25EA6B39AB634774BAC86CED21F3F616"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 124.0d
+                        y: 2.0d
+                        id: "A72D3135FD02446E960C12841856D92B"
+                        tasks: [
+                                {
+                                        id: "5FC08B34AF5549468367FE86EA586A1D"
+                                        type: "item"
+                                        title: "Approfondir allthemodium-1.9.6-1.18.2-40.1.51"
+                                        icon: {
+                                                id: "allthemodium:alloy_pick"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "allthemodium:alloy_pick"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "5A4B937B660B4D6D932D1CDB09431733"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "5923CE8D199C47D499FD365F1AE12AEB"
+                        ]
+                },
+                {
+                        x: 124.0d
+                        y: 4.0d
+                        id: "193DDC0054754922B42B1D8DC945230B"
+                        tasks: [
+                                {
+                                        id: "E25693893700487B973BD398C773B3A5"
+                                        type: "item"
+                                        title: "Ma\u00eetriser allthemodium-1.9.6-1.18.2-40.1.51"
+                                        icon: {
+                                                id: "allthemodium:alloy_shovel"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "allthemodium:alloy_shovel"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "99EBAA55F3954816B32810F8F4C968F3"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "A72D3135FD02446E960C12841856D92B"
+                        ]
+                },
+                {
+                        x: 128.0d
+                        y: 0.0d
+                        id: "81FF4E0DEE044E3D9F0E25D24F501DB8"
+                        tasks: [
+                                {
+                                        id: "8EDD6290FAF74AC1BA24610DF227DDC6"
+                                        type: "item"
+                                        title: "D\u00e9couvrir alltheores-1.9.9m-1.18.2-40.1.0"
+                                        icon: {
+                                                id: "alltheores:aluminum_block"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "alltheores:aluminum_block"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "1CD72A8125B242F6BD6EBD39B7D64FF1"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 128.0d
+                        y: 2.0d
+                        id: "79FADD5E206A462F832D37A6610C6B5F"
+                        tasks: [
+                                {
+                                        id: "1466DE23D2BC4D25BEA563DF0EBD3906"
+                                        type: "item"
+                                        title: "Approfondir alltheores-1.9.9m-1.18.2-40.1.0"
+                                        icon: {
+                                                id: "alltheores:aluminum_clump"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "alltheores:aluminum_clump"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "E3B8D0D976F14075BD64E2725AAC9700"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "81FF4E0DEE044E3D9F0E25D24F501DB8"
+                        ]
+                },
+                {
+                        x: 128.0d
+                        y: 4.0d
+                        id: "FB1DBBE0BE5D4A389D6E4813A9FF5986"
+                        tasks: [
+                                {
+                                        id: "1B0C3CB0A641427B881B302E83F2F03D"
+                                        type: "item"
+                                        title: "Ma\u00eetriser alltheores-1.9.9m-1.18.2-40.1.0"
+                                        icon: {
+                                                id: "alltheores:aluminum_crystal"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "alltheores:aluminum_crystal"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "DDB12D38C62F4373AFF55AAEDA34A024"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "79FADD5E206A462F832D37A6610C6B5F"
+                        ]
+                },
+                {
+                        x: 132.0d
+                        y: 0.0d
+                        id: "37AA353D11CB4AD7A8605DE8798781AA"
+                        tasks: [
+                                {
+                                        id: "EE03E0F5BA55431FA7B8E5A36073C307"
+                                        type: "item"
+                                        title: "D\u00e9couvrir aquamirae-5.api10"
+                                        icon: {
+                                                id: "aquamirae:abyssal_amethyst"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "aquamirae:abyssal_amethyst"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "1B68A062F4C64BE78E44C595E6486585"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 132.0d
+                        y: 2.0d
+                        id: "F8EBB77A9F3A41FA8A6C798CB734FAF3"
+                        tasks: [
+                                {
+                                        id: "D32C99407F3641E9BF686E46F110E6C4"
+                                        type: "item"
+                                        title: "Approfondir aquamirae-5.api10"
+                                        icon: {
+                                                id: "aquamirae:abyssal_boots"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "aquamirae:abyssal_boots"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "0E5698AAD421491CBE003CEBCCA074E3"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "37AA353D11CB4AD7A8605DE8798781AA"
+                        ]
+                },
+                {
+                        x: 132.0d
+                        y: 4.0d
+                        id: "993B36889B82419C81DD65BC590F49EC"
+                        tasks: [
+                                {
+                                        id: "BB991A3C023F4BF0985EE0923CBBD951"
+                                        type: "item"
+                                        title: "Ma\u00eetriser aquamirae-5.api10"
+                                        icon: {
+                                                id: "aquamirae:abyssal_brigantine"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "aquamirae:abyssal_brigantine"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "C930C185D9274EDE8F9787BC1B8F47CC"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "F8EBB77A9F3A41FA8A6C798CB734FAF3"
+                        ]
+                },
+                {
+                        x: 136.0d
+                        y: 0.0d
+                        id: "83EDCA731AF743B697CB8329093A099E"
+                        tasks: [
+                                {
+                                        id: "F7C68DC3164F429280F389983D887CAA"
+                                        type: "item"
+                                        title: "D\u00e9couvrir betteranimalsplus-1.18.2-11.0.10-forge"
+                                        icon: {
+                                                id: "betteranimalsplus:advancement_icon_badger"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "betteranimalsplus:advancement_icon_badger"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "02ACB8895D454FA0808D70CDC56BB304"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 136.0d
+                        y: 2.0d
+                        id: "C988521F633C42C3967617B8C1543E6A"
+                        tasks: [
+                                {
+                                        id: "58E63E888C66437BB9CD16AAD9C40B6F"
+                                        type: "item"
+                                        title: "Approfondir betteranimalsplus-1.18.2-11.0.10-forge"
+                                        icon: {
+                                                id: "betteranimalsplus:advancement_icon_jellyfish"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "betteranimalsplus:advancement_icon_jellyfish"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "2B8071FE160A4FDABD931059DF8821E1"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "83EDCA731AF743B697CB8329093A099E"
+                        ]
+                },
+                {
+                        x: 136.0d
+                        y: 4.0d
+                        id: "D8709177086C40809246FB9C3D939190"
+                        tasks: [
+                                {
+                                        id: "B2CF8583BDCB4FCB89E8B6DA394C6F77"
+                                        type: "item"
+                                        title: "Ma\u00eetriser betteranimalsplus-1.18.2-11.0.10-forge"
+                                        icon: {
+                                                id: "betteranimalsplus:advancement_icon_jellyfish_cross"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "betteranimalsplus:advancement_icon_jellyfish_cross"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "B297C84D3CDD4B09BAB528CEB32D026A"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "C988521F633C42C3967617B8C1543E6A"
+                        ]
+                },
+                {
+                        x: 140.0d
+                        y: 0.0d
+                        id: "89899CD2E289400BAEFB864B64C5E1A9"
+                        tasks: [
+                                {
+                                        id: "7324571798E44F3DA1A5AC5C524FC93E"
+                                        type: "item"
+                                        title: "D\u00e9couvrir blocksyouneed_luna-1.9.1-forge-1.18.2"
+                                        icon: {
+                                                id: "blocksyouneed_luna:acacia_brace"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "blocksyouneed_luna:acacia_brace"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "F9DEB9C54E0747A3BE8F7B50A476276D"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 140.0d
+                        y: 2.0d
+                        id: "39BDF84F95264FB191EB11D2BF59D552"
+                        tasks: [
+                                {
+                                        id: "33649BFE05D44D71AE6B6B1A2879F50D"
+                                        type: "item"
+                                        title: "Approfondir blocksyouneed_luna-1.9.1-forge-1.18.2"
+                                        icon: {
+                                                id: "blocksyouneed_luna:acacia_carved_log"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "blocksyouneed_luna:acacia_carved_log"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "75BCA5E35A734893922B5EFC94464BE5"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "89899CD2E289400BAEFB864B64C5E1A9"
+                        ]
+                },
+                {
+                        x: 140.0d
+                        y: 4.0d
+                        id: "4E789A33D36D4661AC7652AA6B309B1C"
+                        tasks: [
+                                {
+                                        id: "F532C8C13D6442F6887CD17C0AE3CAA1"
+                                        type: "item"
+                                        title: "Ma\u00eetriser blocksyouneed_luna-1.9.1-forge-1.18.2"
+                                        icon: {
+                                                id: "blocksyouneed_luna:acacia_dock_tie"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "blocksyouneed_luna:acacia_dock_tie"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "318857F5CACD49BAA0F9E58042D2FF78"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "39BDF84F95264FB191EB11D2BF59D552"
+                        ]
+                },
+                {
+                        x: 144.0d
+                        y: 0.0d
+                        id: "9B0A3DD3995542F9B4266CCCAC8F88F9"
+                        tasks: [
+                                {
+                                        id: "E71100BE857E4D81956CEA69FD47F167"
+                                        type: "item"
+                                        title: "D\u00e9couvrir born_in_chaos_[Forge]1.18.2_1.17"
+                                        icon: {
+                                                id: "born_in_chaos_v1:ai"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "born_in_chaos_v1:ai"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "77A9114E80764A60BFCF5D89C61A2F25"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 144.0d
+                        y: 2.0d
+                        id: "E71E3C3B215D4818AD84510927FC1475"
+                        tasks: [
+                                {
+                                        id: "4C34D5B4A5AE477285705CE21247B941"
+                                        type: "item"
+                                        title: "Approfondir born_in_chaos_[Forge]1.18.2_1.17"
+                                        icon: {
+                                                id: "born_in_chaos_v1:anluka_doors"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "born_in_chaos_v1:anluka_doors"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "10347AEBB6344C8DAF33362ABB8FCD25"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "9B0A3DD3995542F9B4266CCCAC8F88F9"
+                        ]
+                },
+                {
+                        x: 144.0d
+                        y: 4.0d
+                        id: "A6AD17A8FA9F44A994A05403D47673A9"
+                        tasks: [
+                                {
+                                        id: "CF4EB60EF0DF4318BE2BB4699776BB31"
+                                        type: "item"
+                                        title: "Ma\u00eetriser born_in_chaos_[Forge]1.18.2_1.17"
+                                        icon: {
+                                                id: "born_in_chaos_v1:argillite_lamp"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "born_in_chaos_v1:argillite_lamp"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "D9D4A1A5678248EF8E1413F8A14E84A8"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "E71E3C3B215D4818AD84510927FC1475"
+                        ]
+                },
+                {
+                        x: 148.0d
+                        y: 0.0d
+                        id: "F51267600FB54C3381F02079611108BF"
+                        tasks: [
+                                {
+                                        id: "4166CFA345484C73AC317E7855D3FC76"
+                                        type: "item"
+                                        title: "D\u00e9couvrir buildersaddition-1.18.2-20220308a"
+                                        icon: {
+                                                id: "buildersaddition:acacia_vertical_slab"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "buildersaddition:acacia_vertical_slab"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "F3EB3416189E4F64B8E69E8F14F230AF"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 148.0d
+                        y: 2.0d
+                        id: "1ACC68AD0F674E089969C26450783261"
+                        tasks: [
+                                {
+                                        id: "DA1596C6B76A438DACFF58A7894C7A86"
+                                        type: "item"
+                                        title: "Approfondir buildersaddition-1.18.2-20220308a"
+                                        icon: {
+                                                id: "buildersaddition:andesite_vertical_slab"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "buildersaddition:andesite_vertical_slab"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "95FBBC47A1AE4EE38269E969AD089DC6"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "F51267600FB54C3381F02079611108BF"
+                        ]
+                },
+                {
+                        x: 148.0d
+                        y: 4.0d
+                        id: "6536C034EA944B539D91EDFF8492A317"
+                        tasks: [
+                                {
+                                        id: "2778263298B2420091C593C64A54B9B8"
+                                        type: "item"
+                                        title: "Ma\u00eetriser buildersaddition-1.18.2-20220308a"
+                                        icon: {
+                                                id: "buildersaddition:arcade"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "buildersaddition:arcade"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "D5526EEAC14E40DEB980246C7FE09BEA"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "1ACC68AD0F674E089969C26450783261"
+                        ]
+                },
+                {
+                        x: 152.0d
+                        y: 0.0d
+                        id: "87EAD289D7C04389A3ECF435ACA5995C"
+                        tasks: [
+                                {
+                                        id: "FD10F95978774626B5D6E293A36F0C82"
+                                        type: "item"
+                                        title: "D\u00e9couvrir buildinggadgets-3.13.2-build.21+mc1.18.2"
+                                        icon: {
+                                                id: "buildinggadgets:construction_block"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "buildinggadgets:construction_block"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "BFDF911A8FC14F739BF8627C65BA88ED"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 152.0d
+                        y: 2.0d
+                        id: "D5E7E539C6D84E3C960E591F9EED3139"
+                        tasks: [
+                                {
+                                        id: "5BB32DA2229048D4B58D27716219846C"
+                                        type: "item"
+                                        title: "Approfondir buildinggadgets-3.13.2-build.21+mc1.18.2"
+                                        icon: {
+                                                id: "buildinggadgets:construction_block_dense"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "buildinggadgets:construction_block_dense"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "29A74F18D0914520B59CD1FF81F6B2DE"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "87EAD289D7C04389A3ECF435ACA5995C"
+                        ]
+                },
+                {
+                        x: 152.0d
+                        y: 4.0d
+                        id: "21AA58964528473C8644112741DAD2B7"
+                        tasks: [
+                                {
+                                        id: "6502A2128ABA491BB65AE2420D8F715C"
+                                        type: "item"
+                                        title: "Ma\u00eetriser buildinggadgets-3.13.2-build.21+mc1.18.2"
+                                        icon: {
+                                                id: "buildinggadgets:construction_block_powder"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "buildinggadgets:construction_block_powder"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "8ACA74A185044112A52022551AC84D64"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "D5E7E539C6D84E3C960E591F9EED3139"
+                        ]
+                },
+                {
+                        x: 156.0d
+                        y: 0.0d
+                        id: "50A853BB02B94757AFB650575E3B45D4"
+                        tasks: [
+                                {
+                                        id: "CD82406B3728453E95B8E3A30B1A19EF"
+                                        type: "item"
+                                        title: "D\u00e9couvrir camera-1.18.2-1.0.6"
+                                        icon: {
+                                                id: "camera:album"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "camera:album"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "F6DDD995498C43FFB7156D6C21302370"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 156.0d
+                        y: 2.0d
+                        id: "DDC9F61F60E24292B511682F15F6A8E6"
+                        tasks: [
+                                {
+                                        id: "1D4097E2987649D59C99D1B5DF05D429"
+                                        type: "item"
+                                        title: "Approfondir camera-1.18.2-1.0.6"
+                                        icon: {
+                                                id: "camera:camera"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "camera:camera"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "F983934918EC4650B97BD4BECCB616FE"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "50A853BB02B94757AFB650575E3B45D4"
+                        ]
+                },
+                {
+                        x: 156.0d
+                        y: 4.0d
+                        id: "A2CB4C1B81BE4220B3F87619C44183AD"
+                        tasks: [
+                                {
+                                        id: "EA87EA1DF01A496CBA0F569329D56D42"
+                                        type: "item"
+                                        title: "Ma\u00eetriser camera-1.18.2-1.0.6"
+                                        icon: {
+                                                id: "camera:image"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "camera:image"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "8EB3BEFDF37A4B37A156CA1AC52CC853"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "DDC9F61F60E24292B511682F15F6A8E6"
+                        ]
+                },
+                {
+                        x: 160.0d
+                        y: 0.0d
+                        id: "4CF2C34BA3C54118ACA68C102996E618"
+                        tasks: [
+                                {
+                                        id: "65C6E432573F4D0A8601E4AF3C52516B"
+                                        type: "item"
+                                        title: "D\u00e9couvrir car-1.18.2-1.0.1"
+                                        icon: {
+                                                id: "car:acacia_body"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "car:acacia_body"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "7FB6BBEA38284BD9A310DCB03A0C60FF"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 160.0d
+                        y: 2.0d
+                        id: "C6591856459145DFBDB7F8F61BA4CB88"
+                        tasks: [
+                                {
+                                        id: "FDE09A86CEE3434B8FCBC2844A3B5ECF"
+                                        type: "item"
+                                        title: "Approfondir car-1.18.2-1.0.1"
+                                        icon: {
+                                                id: "car:acacia_bumper"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "car:acacia_bumper"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "196FB02C9AF74DD0AB505CF32303E67A"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "4CF2C34BA3C54118ACA68C102996E618"
+                        ]
+                },
+                {
+                        x: 160.0d
+                        y: 4.0d
+                        id: "0A9D4A03751542ECA22CDE346087091F"
+                        tasks: [
+                                {
+                                        id: "7A3B6D3BE53745C187691B3B08F53E9D"
+                                        type: "item"
+                                        title: "Ma\u00eetriser car-1.18.2-1.0.1"
+                                        icon: {
+                                                id: "car:acacia_license_plate_holder"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "car:acacia_license_plate_holder"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "8CE57BE843314F948B2C1959EE7AC9AF"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "C6591856459145DFBDB7F8F61BA4CB88"
+                        ]
+                },
+                {
+                        x: 164.0d
+                        y: 0.0d
+                        id: "8DBCB5DC3DF847CB810D00CE06C59443"
+                        tasks: [
+                                {
+                                        id: "F006F63A4457430F926438D7CA538816"
+                                        type: "item"
+                                        title: "D\u00e9couvrir cfm-7.0.0-pre35-1.18.2"
+                                        icon: {
+                                                id: "cfm:acacia_bedside_cabinet"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "cfm:acacia_bedside_cabinet"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "CE388F6FECE549FAB6ED9A1868972680"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 164.0d
+                        y: 2.0d
+                        id: "E6439987D8BD47A4BCF6CD79150A9EBB"
+                        tasks: [
+                                {
+                                        id: "5FA7EE24D62348A3A08A67DA3E953B1C"
+                                        type: "item"
+                                        title: "Approfondir cfm-7.0.0-pre35-1.18.2"
+                                        icon: {
+                                                id: "cfm:acacia_blinds"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "cfm:acacia_blinds"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "A29F6D3F488349A982D9930EAABB9EB4"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "8DBCB5DC3DF847CB810D00CE06C59443"
+                        ]
+                },
+                {
+                        x: 164.0d
+                        y: 4.0d
+                        id: "43D4C53DF6D94BA995019BC1263D6052"
+                        tasks: [
+                                {
+                                        id: "BD0F695CA76E47DEBCC7E09C9D120E07"
+                                        type: "item"
+                                        title: "Ma\u00eetriser cfm-7.0.0-pre35-1.18.2"
+                                        icon: {
+                                                id: "cfm:acacia_cabinet"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "cfm:acacia_cabinet"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "5E20043513244CB19FA3B2CEA11C4FFA"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "E6439987D8BD47A4BCF6CD79150A9EBB"
+                        ]
+                },
+                {
+                        x: 168.0d
+                        y: 0.0d
+                        id: "344AC127BC524154A1E13A09D584212D"
+                        tasks: [
+                                {
+                                        id: "18A088BF47BB4E89B26BE479FAA00ECD"
+                                        type: "item"
+                                        title: "D\u00e9couvrir chipped-forge-1.18.2-2.0.1"
+                                        icon: {
+                                                id: "chipped:acacia_door_1"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "chipped:acacia_door_1"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "8A9D16828C4A45BF912AE7FFC9E073BD"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 168.0d
+                        y: 2.0d
+                        id: "A603088A637948D79ACF2D73A7337A7B"
+                        tasks: [
+                                {
+                                        id: "1FE8E15BF3864ED985F9365451332EC2"
+                                        type: "item"
+                                        title: "Approfondir chipped-forge-1.18.2-2.0.1"
+                                        icon: {
+                                                id: "chipped:acacia_door_10"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "chipped:acacia_door_10"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "1C4CECF2EC404C229F38BB7EE2011121"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "344AC127BC524154A1E13A09D584212D"
+                        ]
+                },
+                {
+                        x: 168.0d
+                        y: 4.0d
+                        id: "153938AFF3AA4C8F894721470DD18FAA"
+                        tasks: [
+                                {
+                                        id: "E899342B2949447FBB96B3835CA3AF21"
+                                        type: "item"
+                                        title: "Ma\u00eetriser chipped-forge-1.18.2-2.0.1"
+                                        icon: {
+                                                id: "chipped:acacia_door_11"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "chipped:acacia_door_11"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "8204210E102F4241AB65A12BBA38DE52"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "A603088A637948D79ACF2D73A7337A7B"
+                        ]
+                },
+                {
+                        x: 172.0d
+                        y: 0.0d
+                        id: "4028C7311701400A87A91638C62F043C"
+                        tasks: [
+                                {
+                                        id: "9C88CB604F324427987FD5F98B56647E"
+                                        type: "item"
+                                        title: "D\u00e9couvrir citadel-1.11.3-1.18.2"
+                                        icon: {
+                                                id: "citadel:citadel_book"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "citadel:citadel_book"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "0A5CB653BE8E4DE6AF8AAD7AD122936D"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 172.0d
+                        y: 2.0d
+                        id: "DFE7ABB8EBB64644B5DBE5D6BB4BD759"
+                        tasks: [
+                                {
+                                        id: "9E6D6594B53C48D9A2B595A786B01B77"
+                                        type: "item"
+                                        title: "Approfondir citadel-1.11.3-1.18.2"
+                                        icon: {
+                                                id: "citadel:debug"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "citadel:debug"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "FADDB8E6B01B4C62876CBDFF04F9AF76"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "4028C7311701400A87A91638C62F043C"
+                        ]
+                },
+                {
+                        x: 172.0d
+                        y: 4.0d
+                        id: "DD29AB5150314345980DC03071BB48FA"
+                        tasks: [
+                                {
+                                        id: "4324E850405140DE95A800A32C97A5C9"
+                                        type: "item"
+                                        title: "Ma\u00eetriser citadel-1.11.3-1.18.2"
+                                        icon: {
+                                                id: "citadel:effect_item"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "citadel:effect_item"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "D90E600ADFD34A84BE88739948625296"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "DFE7ABB8EBB64644B5DBE5D6BB4BD759"
+                        ]
+                },
+                {
+                        x: 176.0d
+                        y: 0.0d
+                        id: "B8DF703A9A4B4CA9A29673B8F968AFA8"
+                        tasks: [
+                                {
+                                        id: "E9C75EBCF0B44C339EB0E3B44CD20CF0"
+                                        type: "item"
+                                        title: "D\u00e9couvrir coloredbricks-1.18-5.2"
+                                        icon: {
+                                                id: "coloredbricks:black_brick"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "coloredbricks:black_brick"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "166A33553C14471B89DF19EE3CFF8CBB"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 176.0d
+                        y: 2.0d
+                        id: "FD75903FB70143E592E0C36C99C3337D"
+                        tasks: [
+                                {
+                                        id: "33831C04A3D7451AB62DB167BFE265A3"
+                                        type: "item"
+                                        title: "Approfondir coloredbricks-1.18-5.2"
+                                        icon: {
+                                                id: "coloredbricks:black_brick_slab"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "coloredbricks:black_brick_slab"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "A221AE1AB49A478F93E656123ECD9AEE"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "B8DF703A9A4B4CA9A29673B8F968AFA8"
+                        ]
+                },
+                {
+                        x: 176.0d
+                        y: 4.0d
+                        id: "25AC0ABEDCC24FDD8D0E1C764855564E"
+                        tasks: [
+                                {
+                                        id: "DD72E02CC197480D9F3B6E62E711883C"
+                                        type: "item"
+                                        title: "Ma\u00eetriser coloredbricks-1.18-5.2"
+                                        icon: {
+                                                id: "coloredbricks:black_brick_stairs"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "coloredbricks:black_brick_stairs"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "BFC6F4EB6DE249A480CCF1205FF1972C"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "FD75903FB70143E592E0C36C99C3337D"
+                        ]
+                },
+                {
+                        x: 180.0d
+                        y: 0.0d
+                        id: "F1712EC7D39B4AF390C4F845D617E562"
+                        tasks: [
+                                {
+                                        id: "EDE78D79A11640F385F46C40055BF8BE"
+                                        type: "item"
+                                        title: "D\u00e9couvrir constructionwand-1.18.2-2.9"
+                                        icon: {
+                                                id: "constructionwand:core_angel"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "constructionwand:core_angel"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "1D0DF9D639CD4ECE9803DB621CA66B5D"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 180.0d
+                        y: 2.0d
+                        id: "617E38D744F14712A06B665B988C1542"
+                        tasks: [
+                                {
+                                        id: "0302B9EEC3E9405FAFD68249AF36B675"
+                                        type: "item"
+                                        title: "Approfondir constructionwand-1.18.2-2.9"
+                                        icon: {
+                                                id: "constructionwand:core_destruction"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "constructionwand:core_destruction"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "62B96ABA329D4385AD4B79B3693FA852"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "F1712EC7D39B4AF390C4F845D617E562"
+                        ]
+                },
+                {
+                        x: 180.0d
+                        y: 4.0d
+                        id: "34446201013947D7AB772E2DCDEF5D3F"
+                        tasks: [
+                                {
+                                        id: "B8804CA3D2BD4BC6B2EC2938A4FEDF8E"
+                                        type: "item"
+                                        title: "Ma\u00eetriser constructionwand-1.18.2-2.9"
+                                        icon: {
+                                                id: "constructionwand:diamond_wand"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "constructionwand:diamond_wand"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "103DF41EF99C4485A0A2C812622F098B"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "617E38D744F14712A06B665B988C1542"
+                        ]
+                },
+                {
+                        x: 184.0d
+                        y: 0.0d
+                        id: "7AB31AE776E04BB9B0F485DCA518065D"
+                        tasks: [
+                                {
+                                        id: "EA9EE30C6F7642A2AA13F8BA1532D098"
+                                        type: "item"
+                                        title: "D\u00e9couvrir cookingforblockheads-forge-1.18.2-12.2.0"
+                                        icon: {
+                                                id: "cookingforblockheads:black_kitchen_floor"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "cookingforblockheads:black_kitchen_floor"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "2E2F1E5CBDAB402B85D87552C77DC7EC"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 184.0d
+                        y: 2.0d
+                        id: "11084FD8B4764286998B2C6D56337B9D"
+                        tasks: [
+                                {
+                                        id: "4763B95C4E864A10AA804C8B454BF46B"
+                                        type: "item"
+                                        title: "Approfondir cookingforblockheads-forge-1.18.2-12.2.0"
+                                        icon: {
+                                                id: "cookingforblockheads:blue_kitchen_floor"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "cookingforblockheads:blue_kitchen_floor"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "2EAB298024FF4C0D990B2889D03996FE"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "7AB31AE776E04BB9B0F485DCA518065D"
+                        ]
+                },
+                {
+                        x: 184.0d
+                        y: 4.0d
+                        id: "DE1AE840DA4B43B8B795F3A2AF17EB12"
+                        tasks: [
+                                {
+                                        id: "6A2F7475BDC145E886217D99EAEF8A30"
+                                        type: "item"
+                                        title: "Ma\u00eetriser cookingforblockheads-forge-1.18.2-12.2.0"
+                                        icon: {
+                                                id: "cookingforblockheads:brown_kitchen_floor"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "cookingforblockheads:brown_kitchen_floor"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "C605D35295AB4C18A91BF0FE80E2B4E7"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "11084FD8B4764286998B2C6D56337B9D"
+                        ]
+                },
+                {
+                        x: 188.0d
+                        y: 0.0d
+                        id: "BC1655E2FA364AF78DBE411A805C2CF0"
+                        tasks: [
+                                {
+                                        id: "95EA4EFA672D498EBC3D57A3B6AE515A"
+                                        type: "item"
+                                        title: "D\u00e9couvrir create-1.18.2-0.5.1.i"
+                                        icon: {
+                                                id: "create:acacia_window"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "create:acacia_window"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "60BC58FA3F5C420DA2F2A4458AC1DD53"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 188.0d
+                        y: 2.0d
+                        id: "DCE23B1E23DC4CF9B8E4FD7229F537ED"
+                        tasks: [
+                                {
+                                        id: "059213A42B874B49997466E6D6FFF29A"
+                                        type: "item"
+                                        title: "Approfondir create-1.18.2-0.5.1.i"
+                                        icon: {
+                                                id: "create:acacia_window_pane"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "create:acacia_window_pane"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "011009A6234B4050982C23C8104D9E5F"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "BC1655E2FA364AF78DBE411A805C2CF0"
+                        ]
+                },
+                {
+                        x: 188.0d
+                        y: 4.0d
+                        id: "7AB30C1D94E840C7AE6A345B94666BDA"
+                        tasks: [
+                                {
+                                        id: "A60E23E7DE8E4FE98027D3D407702A33"
+                                        type: "item"
+                                        title: "Ma\u00eetriser create-1.18.2-0.5.1.i"
+                                        icon: {
+                                                id: "create:accelerator"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "create:accelerator"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "F0966F10A9284A66BC84C18500640712"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "DCE23B1E23DC4CF9B8E4FD7229F537ED"
+                        ]
+                },
+                {
+                        x: 192.0d
+                        y: 0.0d
+                        id: "278B3DFB6BC6454B9FBBF69C046E4D4D"
+                        tasks: [
+                                {
+                                        id: "E0F0267CB6164DF7AA5F8E09D8D0B4C3"
+                                        type: "item"
+                                        title: "D\u00e9couvrir create_central_kitchen-1.18.2-for-create-0.5.1.f-1.3.9.d"
+                                        icon: {
+                                                id: "create_central_kitchen:aloe_cake_slice"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "create_central_kitchen:aloe_cake_slice"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "BF9B90AD872846F3B48B7BDF4976354D"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 192.0d
+                        y: 2.0d
+                        id: "B79314CFCC584588AF94E81C5609F272"
+                        tasks: [
+                                {
+                                        id: "E0C8D1427DB44381B2B615F4FA988D55"
+                                        type: "item"
+                                        title: "Approfondir create_central_kitchen-1.18.2-for-create-0.5.1.f-1.3.9.d"
+                                        icon: {
+                                                id: "create_central_kitchen:aloe_gel_bucket"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "create_central_kitchen:aloe_gel_bucket"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "F23F0B484DBC4FECAB6AA203D0966887"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "278B3DFB6BC6454B9FBBF69C046E4D4D"
+                        ]
+                },
+                {
+                        x: 192.0d
+                        y: 4.0d
+                        id: "5B27CE6BDDC34433A18B2DD85716F689"
+                        tasks: [
+                                {
+                                        id: "7673BBD6935A40AFB2C73E3FFB7A86F1"
+                                        type: "item"
+                                        title: "Ma\u00eetriser create_central_kitchen-1.18.2-for-create-0.5.1.f-1.3.9.d"
+                                        icon: {
+                                                id: "create_central_kitchen:brewing_guide"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "create_central_kitchen:brewing_guide"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "A04A4FFDE70A417A8CEE10C524E7F2D5"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "B79314CFCC584588AF94E81C5609F272"
+                        ]
+                },
+                {
+                        x: 196.0d
+                        y: 0.0d
+                        id: "9BE9C3116801437A8359C3FE978ACDEF"
+                        tasks: [
+                                {
+                                        id: "815CDC64506048DE8D41D69824CB8CC5"
+                                        type: "item"
+                                        title: "D\u00e9couvrir create_enchantment_industry-1.18.2-for-create-0.5.1.f-1.2.8"
+                                        icon: {
+                                                id: "create_enchantment_industry:disenchanter"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "create_enchantment_industry:disenchanter"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "A529C58CD6AB40C9BC1F73C3A63DA0D5"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 196.0d
+                        y: 2.0d
+                        id: "64D3A1F7303F4389950BD0840F2BB217"
+                        tasks: [
+                                {
+                                        id: "620C5A17776D4D8793D407B2877AD1A2"
+                                        type: "item"
+                                        title: "Approfondir create_enchantment_industry-1.18.2-for-create-0.5.1.f-1.2.8"
+                                        icon: {
+                                                id: "create_enchantment_industry:enchanting_guide"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "create_enchantment_industry:enchanting_guide"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "90C23531D1454519AFFEEB46D29CBF89"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "9BE9C3116801437A8359C3FE978ACDEF"
+                        ]
+                },
+                {
+                        x: 196.0d
+                        y: 4.0d
+                        id: "190F4E8448084533891676BD3F09CD58"
+                        tasks: [
+                                {
+                                        id: "A55B880FB9CB45C7B8266F4FBCA3FED6"
+                                        type: "item"
+                                        title: "Ma\u00eetriser create_enchantment_industry-1.18.2-for-create-0.5.1.f-1.2.8"
+                                        icon: {
+                                                id: "create_enchantment_industry:experience_rotor"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "create_enchantment_industry:experience_rotor"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "D69C7FC057C24369971C076C86F696E8"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "64D3A1F7303F4389950BD0840F2BB217"
+                        ]
+                },
+                {
+                        x: 200.0d
+                        y: 0.0d
+                        id: "7D729ECADCB041C7A841D302899AEE47"
+                        tasks: [
+                                {
+                                        id: "7AA229A8AE014E0981A4F6E7E202D395"
+                                        type: "item"
+                                        title: "D\u00e9couvrir createaddition-1.18.2-1.0.0"
+                                        icon: {
+                                                id: "createaddition:accumulator"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "createaddition:accumulator"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "4907C4767AE24A8A897D30ACEFFF4FDD"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 200.0d
+                        y: 2.0d
+                        id: "18DF92ED79124DD68BA50819B8CF43A2"
+                        tasks: [
+                                {
+                                        id: "D9BF6B41791F4A93AB2489D3FFFDD4CB"
+                                        type: "item"
+                                        title: "Approfondir createaddition-1.18.2-1.0.0"
+                                        icon: {
+                                                id: "createaddition:alternator"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "createaddition:alternator"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "D92D204293F9420BB9C253445F60AE93"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "7D729ECADCB041C7A841D302899AEE47"
+                        ]
+                },
+                {
+                        x: 200.0d
+                        y: 4.0d
+                        id: "D8615C54530D400CB71EC806CDD1DCEA"
+                        tasks: [
+                                {
+                                        id: "4F804FF5596348E4A5102C5F8AF95FCE"
+                                        type: "item"
+                                        title: "Ma\u00eetriser createaddition-1.18.2-1.0.0"
+                                        icon: {
+                                                id: "createaddition:barbed_wire"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "createaddition:barbed_wire"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "CA7B353ADEEC49FD899866C1B26A23DA"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "18DF92ED79124DD68BA50819B8CF43A2"
+                        ]
+                },
+                {
+                        x: 204.0d
+                        y: 0.0d
+                        id: "7B209DF2FE3449A58B6FAE4D06590B72"
+                        tasks: [
+                                {
+                                        id: "956039C050A3433BA890AA11A9B8FA14"
+                                        type: "item"
+                                        title: "D\u00e9couvrir creativewirelesstransmitter-1.18.2-1.2"
+                                        icon: {
+                                                id: "creativewirelesstransmitter:black_creative_wireless_transmitter"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "creativewirelesstransmitter:black_creative_wireless_transmitter"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "128FB80EFC2A4125B2367354DD6DD0AE"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 204.0d
+                        y: 2.0d
+                        id: "8CC6CCEEE939489BA95CB23F8957AD7B"
+                        tasks: [
+                                {
+                                        id: "5AFE550A99A245D3B07634C30B4298AB"
+                                        type: "item"
+                                        title: "Approfondir creativewirelesstransmitter-1.18.2-1.2"
+                                        icon: {
+                                                id: "creativewirelesstransmitter:blue_creative_wireless_transmitter"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "creativewirelesstransmitter:blue_creative_wireless_transmitter"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "AE438D110B564C938B9502CAA81230B9"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "7B209DF2FE3449A58B6FAE4D06590B72"
+                        ]
+                },
+                {
+                        x: 204.0d
+                        y: 4.0d
+                        id: "F5721CB213504851BE51C93351A3CCA5"
+                        tasks: [
+                                {
+                                        id: "4C00FE9152624980BCF1CD8D2B608D0C"
+                                        type: "item"
+                                        title: "Ma\u00eetriser creativewirelesstransmitter-1.18.2-1.2"
+                                        icon: {
+                                                id: "creativewirelesstransmitter:brown_creative_wireless_transmitter"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "creativewirelesstransmitter:brown_creative_wireless_transmitter"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "6680EFA07E5C47CD8EC232F5BF98923B"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "8CC6CCEEE939489BA95CB23F8957AD7B"
+                        ]
+                },
+                {
+                        x: 208.0d
+                        y: 0.0d
+                        id: "4B4662391F0C438EBF9B65D5B5E0204E"
+                        tasks: [
+                                {
+                                        id: "BBA9437290C04FE4AD16DEA09E9C30A9"
+                                        type: "item"
+                                        title: "D\u00e9couvrir fossil-forge-1.18.2-9.1.5.1"
+                                        icon: {
+                                                id: "fossil:alligator_gar_dna"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "fossil:alligator_gar_dna"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "0C3B08CB9D70421FA3072FE77343E9F1"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 208.0d
+                        y: 2.0d
+                        id: "6C0D9ECF11B3497EB90028CB39D049AB"
+                        tasks: [
+                                {
+                                        id: "7565E29C8AD1454FA49AEBCC99B6311A"
+                                        type: "item"
+                                        title: "Approfondir fossil-forge-1.18.2-9.1.5.1"
+                                        icon: {
+                                                id: "fossil:allosaurus_dna"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "fossil:allosaurus_dna"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "62A2BBACD4444162B01982EB9A1719C0"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "4B4662391F0C438EBF9B65D5B5E0204E"
+                        ]
+                },
+                {
+                        x: 208.0d
+                        y: 4.0d
+                        id: "7372BBFC1A32453292A4EFF328952C9A"
+                        tasks: [
+                                {
+                                        id: "F75594DD42DB48D2B9C0159F522A519A"
+                                        type: "item"
+                                        title: "Ma\u00eetriser fossil-forge-1.18.2-9.1.5.1"
+                                        icon: {
+                                                id: "fossil:amber_block"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "fossil:amber_block"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "6E93E9A7986F4BFBADFDB37F75B9D123"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "6C0D9ECF11B3497EB90028CB39D049AB"
+                        ]
+                },
+                {
+                        x: 212.0d
+                        y: 0.0d
+                        id: "01C00C5162C1460EAD68BBE4786D7378"
+                        tasks: [
+                                {
+                                        id: "64616F6A458940648C9ED85C7D37CB9B"
+                                        type: "item"
+                                        title: "D\u00e9couvrir ftb-library-forge-1802.3.11-build.177"
+                                        icon: {
+                                                id: "ftblibrary:fluid_container"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "ftblibrary:fluid_container"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "40E23466B130434C86CC90C31D066495"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 216.0d
+                        y: 0.0d
+                        id: "0EEB103F7A5B4BBB852EC635AD0B3B5D"
+                        tasks: [
+                                {
+                                        id: "E63436A27FD44F8FB6588E307BBFA796"
+                                        type: "item"
+                                        title: "D\u00e9couvrir ftb-ultimine-forge-1802.3.4-build.93"
+                                        icon: {
+                                                id: "ftbultimine:ultiminer"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "ftbultimine:ultiminer"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "1C0BACCEE9694B10AD77554A1F1CAB50"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 220.0d
+                        y: 0.0d
+                        id: "8186FD3DF1E94456BB8E834233D8A5A9"
+                        tasks: [
+                                {
+                                        id: "AD53E92878B744EDB0AADFC806B6A0F5"
+                                        type: "item"
+                                        title: "D\u00e9couvrir geckolib-forge-1.18-3.0.57"
+                                        icon: {
+                                                id: "geckolib3:botarium"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "geckolib3:botarium"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "C6E84DDE6BCC48B9A6B29C7C5B4D3F45"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 220.0d
+                        y: 2.0d
+                        id: "B01505B4D8644107AB65ED0BF0EAE22F"
+                        tasks: [
+                                {
+                                        id: "7BC4F8011D2047DD9E2785BFDC3170E5"
+                                        type: "item"
+                                        title: "Approfondir geckolib-forge-1.18-3.0.57"
+                                        icon: {
+                                                id: "geckolib3:botariumblock"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "geckolib3:botariumblock"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "110BD3DB69BE4B58B93717A46C29B39B"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "8186FD3DF1E94456BB8E834233D8A5A9"
+                        ]
+                },
+                {
+                        x: 220.0d
+                        y: 4.0d
+                        id: "78A3D18AEFC34FCFB0B70638D400A08C"
+                        tasks: [
+                                {
+                                        id: "1BF60D0D8065461689E1908D5BBD523F"
+                                        type: "item"
+                                        title: "Ma\u00eetriser geckolib-forge-1.18-3.0.57"
+                                        icon: {
+                                                id: "geckolib3:fertilizer"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "geckolib3:fertilizer"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "A6120DEAD4E0417F8B46AFC636AE7C94"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "B01505B4D8644107AB65ED0BF0EAE22F"
+                        ]
+                },
+                {
+                        x: 224.0d
+                        y: 0.0d
+                        id: "EBC3498C557C4CB0A6C762254B1EB9B1"
+                        tasks: [
+                                {
+                                        id: "1B6E1D9CAAFB4DFEA547328980925101"
+                                        type: "item"
+                                        title: "D\u00e9couvrir guardvillagers-1.18.2.1.4.4"
+                                        icon: {
+                                                id: "guardvillagers:guard_spawn_egg"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "guardvillagers:guard_spawn_egg"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "9F3E95153F414371863246CC0E112BEB"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 224.0d
+                        y: 2.0d
+                        id: "9B70E060EA8E4FE396B6BA9326360292"
+                        tasks: [
+                                {
+                                        id: "52BA56A6D78746DBA5E2E230E4907FC2"
+                                        type: "item"
+                                        title: "Approfondir guardvillagers-1.18.2.1.4.4"
+                                        icon: {
+                                                id: "guardvillagers:illusioner_spawn_egg"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "guardvillagers:illusioner_spawn_egg"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "3C4C6802F1214601A2277F6F92890A7E"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "EBC3498C557C4CB0A6C762254B1EB9B1"
+                        ]
+                },
+                {
+                        x: 224.0d
+                        y: 4.0d
+                        id: "BB43B59F74184F2F82C22DFBF49C24F2"
+                        tasks: [
+                                {
+                                        id: "FD8D4A095FFC4EFCBEC6CF0CFC72EB0A"
+                                        type: "item"
+                                        title: "Ma\u00eetriser guardvillagers-1.18.2.1.4.4"
+                                        icon: {
+                                                id: "guardvillagers:iron_golem_spawn_egg"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "guardvillagers:iron_golem_spawn_egg"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "9EC9AD3551C547EAB2E66524A322B77C"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "9B70E060EA8E4FE396B6BA9326360292"
+                        ]
+                },
+                {
+                        x: 228.0d
+                        y: 0.0d
+                        id: "F9FB6F7F82C7429590B14B66F70807A7"
+                        tasks: [
+                                {
+                                        id: "1E0C25ECB8624B23BBFC0C1E5A955FBF"
+                                        type: "item"
+                                        title: "D\u00e9couvrir hole_filler_mod_1.2.5-mc_1.18.1-forge"
+                                        icon: {
+                                                id: "hole_filler_mod:curing_block"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "hole_filler_mod:curing_block"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "5C973120A6064482B985103C77F2272A"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 228.0d
+                        y: 2.0d
+                        id: "DEF3E5F902B045C495C47B2EE7E653D5"
+                        tasks: [
+                                {
+                                        id: "135798ADD4114495A07BA235482526D6"
+                                        type: "item"
+                                        title: "Approfondir hole_filler_mod_1.2.5-mc_1.18.1-forge"
+                                        icon: {
+                                                id: "hole_filler_mod:hole_filler_block"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "hole_filler_mod:hole_filler_block"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "8C268F64105046F284D0B8DFB5441C2F"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "F9FB6F7F82C7429590B14B66F70807A7"
+                        ]
+                },
+                {
+                        x: 228.0d
+                        y: 4.0d
+                        id: "14D3ED1E988B497D9F530EC7829E7106"
+                        tasks: [
+                                {
+                                        id: "02B3DB42A53C4513B5FE9C6516D784B8"
+                                        type: "item"
+                                        title: "Ma\u00eetriser hole_filler_mod_1.2.5-mc_1.18.1-forge"
+                                        icon: {
+                                                id: "hole_filler_mod:hole_filler_block_balanced"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "hole_filler_mod:hole_filler_block_balanced"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "2E77D04890EE4C47B4A3A890F594E3EC"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "DEF3E5F902B045C495C47B2EE7E653D5"
+                        ]
+                },
+                {
+                        x: 232.0d
+                        y: 0.0d
+                        id: "6D56E267C8DC404D9D6EC7824F256B7C"
+                        tasks: [
+                                {
+                                        id: "A9D1DA61A6244992851DC6BE73C540D5"
+                                        type: "item"
+                                        title: "D\u00e9couvrir idas_forge-1.6.7+1.18.2"
+                                        icon: {
+                                                id: "idas:disc_fragment_slither"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "idas:disc_fragment_slither"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "8AFB946AA5A2456BB5DB5CA95ABAD835"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 232.0d
+                        y: 2.0d
+                        id: "86556419E4B7414B9D6C3FB9AFAFE335"
+                        tasks: [
+                                {
+                                        id: "4FB3BEB2285D4C9681C8C5630AB3B161"
+                                        type: "item"
+                                        title: "Approfondir idas_forge-1.6.7+1.18.2"
+                                        icon: {
+                                                id: "idas:music_disc_calidum"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "idas:music_disc_calidum"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "C9F047914B4640EF9D23D459A7C34F36"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "6D56E267C8DC404D9D6EC7824F256B7C"
+                        ]
+                },
+                {
+                        x: 232.0d
+                        y: 4.0d
+                        id: "DC0893248B9D4AD1AE3709362D85D685"
+                        tasks: [
+                                {
+                                        id: "59FC681FC1FC4B0BA3ACF3E4F60A038C"
+                                        type: "item"
+                                        title: "Ma\u00eetriser idas_forge-1.6.7+1.18.2"
+                                        icon: {
+                                                id: "idas:music_disc_slither"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "idas:music_disc_slither"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "4F81856504D94101AC76B0D9B2EEE8DA"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "86556419E4B7414B9D6C3FB9AFAFE335"
+                        ]
+                },
+                {
+                        x: 236.0d
+                        y: 0.0d
+                        id: "7F3B5D419C2142589F3A19E21B5AB552"
+                        tasks: [
+                                {
+                                        id: "3967105C67D741699140041D05C31A72"
+                                        type: "item"
+                                        title: "D\u00e9couvrir immersive_weathering-1.18.2-3.0.3-forge"
+                                        icon: {
+                                                id: "immersive_weathering:acacia_bark"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "immersive_weathering:acacia_bark"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "6A571F1381EF44ECB655715F599D21C4"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 236.0d
+                        y: 2.0d
+                        id: "87A559D1315A45289A8FC33F99D4A001"
+                        tasks: [
+                                {
+                                        id: "DC9EF7C7DC024E349874BADDBA23BFF7"
+                                        type: "item"
+                                        title: "Approfondir immersive_weathering-1.18.2-3.0.3-forge"
+                                        icon: {
+                                                id: "immersive_weathering:acacia_leaf_pile"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "immersive_weathering:acacia_leaf_pile"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "ECB4BA047DAD497B92418E285413A39A"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "7F3B5D419C2142589F3A19E21B5AB552"
+                        ]
+                },
+                {
+                        x: 236.0d
+                        y: 4.0d
+                        id: "63644C85DC504BF6B7AEAE58AEF6F51F"
+                        tasks: [
+                                {
+                                        id: "C4D401A0C8CB45709741757462E12773"
+                                        type: "item"
+                                        title: "Ma\u00eetriser immersive_weathering-1.18.2-3.0.3-forge"
+                                        icon: {
+                                                id: "immersive_weathering:ash_block"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "immersive_weathering:ash_block"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "BEA06C26A048485096F9F2EEF08F9CA5"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "87A559D1315A45289A8FC33F99D4A001"
+                        ]
+                },
+                {
+                        x: 240.0d
+                        y: 0.0d
+                        id: "270FF913C85642138714411D8B2AA0C5"
+                        tasks: [
+                                {
+                                        id: "29F6FAA12EF34B9A973C37CBFA59A9FD"
+                                        type: "item"
+                                        title: "D\u00e9couvrir ironchest-1.18.2-13.2.11"
+                                        icon: {
+                                                id: "ironchest:copper_chest"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "ironchest:copper_chest"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "76CAEA6B16BC47458C073A9DACAAE654"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 240.0d
+                        y: 2.0d
+                        id: "259D8BC4C0B340329A987F14A09E2BC4"
+                        tasks: [
+                                {
+                                        id: "987390FBD0EC4C888E5A2A6F6645DE6A"
+                                        type: "item"
+                                        title: "Approfondir ironchest-1.18.2-13.2.11"
+                                        icon: {
+                                                id: "ironchest:copper_to_iron_chest_upgrade"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "ironchest:copper_to_iron_chest_upgrade"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "DCC792A02AE8484D833AE6797E8F6286"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "270FF913C85642138714411D8B2AA0C5"
+                        ]
+                },
+                {
+                        x: 240.0d
+                        y: 4.0d
+                        id: "381C4F1EBEFB4A24A6C7184C5C48032A"
+                        tasks: [
+                                {
+                                        id: "3931F452DD004F03A86721DEB5319F15"
+                                        type: "item"
+                                        title: "Ma\u00eetriser ironchest-1.18.2-13.2.11"
+                                        icon: {
+                                                id: "ironchest:crystal_chest"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "ironchest:crystal_chest"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "6ECEC8453FDF4ED5911644D4E05122F9"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "259D8BC4C0B340329A987F14A09E2BC4"
+                        ]
+                },
+                {
+                        x: 244.0d
+                        y: 0.0d
+                        id: "CF505EB8CFCA4DC5887695467C5D4D4D"
+                        tasks: [
+                                {
+                                        id: "659D8B40DCE74A468220AB7EF9E96960"
+                                        type: "item"
+                                        title: "D\u00e9couvrir ironfurnaces-1.18.2-3.3.3"
+                                        icon: {
+                                                id: "ironfurnaces:allthemodium_furnace"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "ironfurnaces:allthemodium_furnace"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "0EDFA496F43A430BA4D2308DC50D1F1A"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 244.0d
+                        y: 2.0d
+                        id: "65B1A81069D54430B1207159773AD87D"
+                        tasks: [
+                                {
+                                        id: "8F1C5A19295246E0A0B3F22D301DFDCF"
+                                        type: "item"
+                                        title: "Approfondir ironfurnaces-1.18.2-3.3.3"
+                                        icon: {
+                                                id: "ironfurnaces:augment_blasting"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "ironfurnaces:augment_blasting"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "EC7461EC28FB4B67B281075D3C7DF3F1"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "CF505EB8CFCA4DC5887695467C5D4D4D"
+                        ]
+                },
+                {
+                        x: 244.0d
+                        y: 4.0d
+                        id: "DC4D01F3585A4EB1813BF1531AEBE59A"
+                        tasks: [
+                                {
+                                        id: "A182B5A8570F404B807A008FE6D3F76E"
+                                        type: "item"
+                                        title: "Ma\u00eetriser ironfurnaces-1.18.2-3.3.3"
+                                        icon: {
+                                                id: "ironfurnaces:augment_factory"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "ironfurnaces:augment_factory"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "B18EA8B0E9784DA6885D2CF253FDEBAC"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "65B1A81069D54430B1207159773AD87D"
+                        ]
+                },
+                {
+                        x: 248.0d
+                        y: 0.0d
+                        id: "59E4AEFB91FD4CB79F5D5755E57424AE"
+                        tasks: [
+                                {
+                                        id: "EA272C4D310D4F3BB9A6ABE1E1F98380"
+                                        type: "item"
+                                        title: "D\u00e9couvrir item-filters-forge-1802.2.8-build.50"
+                                        icon: {
+                                                id: "itemfilters:always_false"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "itemfilters:always_false"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "73D63ECBF5BA44FBBB837EB8FA31A7AC"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 248.0d
+                        y: 2.0d
+                        id: "33C1D816706F4372A05CBEA8690C3FD4"
+                        tasks: [
+                                {
+                                        id: "06DB8186C9384E4AA6F63AE2559854DC"
+                                        type: "item"
+                                        title: "Approfondir item-filters-forge-1802.2.8-build.50"
+                                        icon: {
+                                                id: "itemfilters:always_true"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "itemfilters:always_true"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "0376DE7413D7428E9DBB9E08CDB8FF33"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "59E4AEFB91FD4CB79F5D5755E57424AE"
+                        ]
+                },
+                {
+                        x: 248.0d
+                        y: 4.0d
+                        id: "39E2A447465B4E8FBD29EAED1FB32656"
+                        tasks: [
+                                {
+                                        id: "40D61E5B21AA464EBBA3DFA2B8B699CD"
+                                        type: "item"
+                                        title: "Ma\u00eetriser item-filters-forge-1802.2.8-build.50"
+                                        icon: {
+                                                id: "itemfilters:and"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "itemfilters:and"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "7EBBBEEE42964E73BA6C4F8EE57739A6"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "33C1D816706F4372A05CBEA8690C3FD4"
+                        ]
+                },
+                {
+                        x: 252.0d
+                        y: 0.0d
+                        id: "BA92C93E930547F39B6E551ACFA9BA93"
+                        tasks: [
+                                {
+                                        id: "458C3DEFA9404BCAA0487EEB0097EE1A"
+                                        type: "item"
+                                        title: "D\u00e9couvrir justhammers-forge-0.1.2+mc1.18.2"
+                                        icon: {
+                                                id: "justhammers:destructor_core"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "justhammers:destructor_core"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "B8A00D0C090443B593986F5A8FACC192"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 252.0d
+                        y: 2.0d
+                        id: "9E5B8045E5E84F15928CA24D6CE82DDC"
+                        tasks: [
+                                {
+                                        id: "D8248038CD824F228B86141493C4DC8B"
+                                        type: "item"
+                                        title: "Approfondir justhammers-forge-0.1.2+mc1.18.2"
+                                        icon: {
+                                                id: "justhammers:diamond_destructor_hammer"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "justhammers:diamond_destructor_hammer"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "A898E397B64A4D34B8BE323B2FFE5E97"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "BA92C93E930547F39B6E551ACFA9BA93"
+                        ]
+                },
+                {
+                        x: 252.0d
+                        y: 4.0d
+                        id: "DA5BEBAA6CF14FD4A0EDDF493A1DC8E1"
+                        tasks: [
+                                {
+                                        id: "01B262B9C3C54CC08FB3A9E19012B816"
+                                        type: "item"
+                                        title: "Ma\u00eetriser justhammers-forge-0.1.2+mc1.18.2"
+                                        icon: {
+                                                id: "justhammers:diamond_hammer"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "justhammers:diamond_hammer"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "1228E52F0EE9459D88A30FB74910B8B8"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "9E5B8045E5E84F15928CA24D6CE82DDC"
+                        ]
+                },
+                {
+                        x: 256.0d
+                        y: 0.0d
+                        id: "1D359D8DB6EC414D9F153B7CBFB56369"
+                        tasks: [
+                                {
+                                        id: "552BB363DE1F4A4E82F7E62A28B35D13"
+                                        type: "item"
+                                        title: "D\u00e9couvrir libraryferret-forge-1.18.2-4.0.0"
+                                        icon: {
+                                                id: "libraryferret:diamond_coins_jtl"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "libraryferret:diamond_coins_jtl"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "0C13B772C97D45CB80B60AFB59E03BDB"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 256.0d
+                        y: 2.0d
+                        id: "61D2648AB7CC4664813C9B514B7EC413"
+                        tasks: [
+                                {
+                                        id: "42DA809F024C45A19F7601C5F1E235DB"
+                                        type: "item"
+                                        title: "Approfondir libraryferret-forge-1.18.2-4.0.0"
+                                        icon: {
+                                                id: "libraryferret:emerald_coins_jtl"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "libraryferret:emerald_coins_jtl"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "C4A9432BBFF345799736E18CF438BEB5"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "1D359D8DB6EC414D9F153B7CBFB56369"
+                        ]
+                },
+                {
+                        x: 256.0d
+                        y: 4.0d
+                        id: "3D9F9568B16D47FA9E8ED5865E711CD3"
+                        tasks: [
+                                {
+                                        id: "686602D15F374429B1E682CD1DB8780E"
+                                        type: "item"
+                                        title: "Ma\u00eetriser libraryferret-forge-1.18.2-4.0.0"
+                                        icon: {
+                                                id: "libraryferret:fake_diamond_block"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "libraryferret:fake_diamond_block"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "5DED008A44D44AE2AB1D78C8408A6611"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "61D2648AB7CC4664813C9B514B7EC413"
+                        ]
+                },
+                {
+                        x: 260.0d
+                        y: 0.0d
+                        id: "FFF0888A57F94211901E8B6941F2F157"
+                        tasks: [
+                                {
+                                        id: "02B371CCDC0F4E1891C5252CA099ED98"
+                                        type: "item"
+                                        title: "D\u00e9couvrir lootr-forge-1.18.2-0.3.30.73"
+                                        icon: {
+                                                id: "lootr:crown"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "lootr:crown"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "34C5EEC7A76D4D64AB23606D36C964F1"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 260.0d
+                        y: 2.0d
+                        id: "534F49B26BFA4635966D0924FF1DE25F"
+                        tasks: [
+                                {
+                                        id: "2CE34EF1413D4CCBAABAF1059753521F"
+                                        type: "item"
+                                        title: "Approfondir lootr-forge-1.18.2-0.3.30.73"
+                                        icon: {
+                                                id: "lootr:lootr_barrel"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "lootr:lootr_barrel"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "A9C9FFD414AF436B885ACC64D628FB99"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "FFF0888A57F94211901E8B6941F2F157"
+                        ]
+                },
+                {
+                        x: 260.0d
+                        y: 4.0d
+                        id: "94C5703CBA1E4018857EF33A0F804881"
+                        tasks: [
+                                {
+                                        id: "03A0B4D518614B019CEEA790B35159F4"
+                                        type: "item"
+                                        title: "Ma\u00eetriser lootr-forge-1.18.2-0.3.30.73"
+                                        icon: {
+                                                id: "lootr:lootr_chest"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "lootr:lootr_chest"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "2D417B11775E4B84BB33B1692839DE3D"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "534F49B26BFA4635966D0924FF1DE25F"
+                        ]
+                },
+                {
+                        x: 264.0d
+                        y: 0.0d
+                        id: "1495C03EB5CE490282EE549AFAE8BEDB"
+                        tasks: [
+                                {
+                                        id: "7C23ACE453814EC0AEFF88B5607B5250"
+                                        type: "item"
+                                        title: "D\u00e9couvrir mapperbase-1.18.2-4.0.1.0"
+                                        icon: {
+                                                id: "mapperbase:bolt"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "mapperbase:bolt"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "6D44B71C0C1E4686912E3A3832B41937"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 264.0d
+                        y: 2.0d
+                        id: "02A59EC9093D46F28AC2E33B730C4FA9"
+                        tasks: [
+                                {
+                                        id: "2815271B72B0498E9071B1A40806E0A8"
+                                        type: "item"
+                                        title: "Approfondir mapperbase-1.18.2-4.0.1.0"
+                                        icon: {
+                                                id: "mapperbase:ferrite"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "mapperbase:ferrite"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "54177FD27A73441492745DD31CEB8F0E"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "1495C03EB5CE490282EE549AFAE8BEDB"
+                        ]
+                },
+                {
+                        x: 264.0d
+                        y: 4.0d
+                        id: "6516E39BC3DF45B09A2F967B849E2BA0"
+                        tasks: [
+                                {
+                                        id: "E4B0C7FFE1474FA9A1FB28B3E311031F"
+                                        type: "item"
+                                        title: "Ma\u00eetriser mapperbase-1.18.2-4.0.1.0"
+                                        icon: {
+                                                id: "mapperbase:flatter_hammer"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "mapperbase:flatter_hammer"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "08E9A075CE2B43709CE00BA1081B817B"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "02A59EC9093D46F28AC2E33B730C4FA9"
+                        ]
+                },
+                {
+                        x: 268.0d
+                        y: 0.0d
+                        id: "CFE7A141101A4C50B593E6757C0FE52F"
+                        tasks: [
+                                {
+                                        id: "471909A3B46D441EBC96EF77021F7630"
+                                        type: "item"
+                                        title: "D\u00e9couvrir mcjtylib-1.18-6.0.20"
+                                        icon: {
+                                                id: "mcjtylib:multipart"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "mcjtylib:multipart"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "410F2C1E278C4B6F99F34F791F8188C6"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 272.0d
+                        y: 0.0d
+                        id: "0F771AFF020643F893A6027764AE369B"
+                        tasks: [
+                                {
+                                        id: "34A3DDFE8912462DADD74E319D4CA3FE"
+                                        type: "item"
+                                        title: "D\u00e9couvrir mcmodded-1.0"
+                                        icon: {
+                                                id: "mcmodded:black_brick"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "mcmodded:black_brick"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "71E4578AD66B4F219749620C64D332BA"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 272.0d
+                        y: 2.0d
+                        id: "0B02E532CB0F4E5A920CEF8EBA1B836E"
+                        tasks: [
+                                {
+                                        id: "DF640E015AF1480EA7A500ADF1A7C0CF"
+                                        type: "item"
+                                        title: "Approfondir mcmodded-1.0"
+                                        icon: {
+                                                id: "mcmodded:black_textured"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "mcmodded:black_textured"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "669F4C8093784313B58044D83451237A"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "0F771AFF020643F893A6027764AE369B"
+                        ]
+                },
+                {
+                        x: 272.0d
+                        y: 4.0d
+                        id: "1DC95553746F457699EF6F9B93681AF1"
+                        tasks: [
+                                {
+                                        id: "7C01CE8596C747F98607B9029A25F582"
+                                        type: "item"
+                                        title: "Ma\u00eetriser mcmodded-1.0"
+                                        icon: {
+                                                id: "mcmodded:cave_block"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "mcmodded:cave_block"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "1D17AAA4DB064F41881B5BD54B4C1879"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "0B02E532CB0F4E5A920CEF8EBA1B836E"
+                        ]
+                },
+                {
+                        x: 276.0d
+                        y: 0.0d
+                        id: "4E6726814C45424FA1E45229426F7E72"
+                        tasks: [
+                                {
+                                        id: "C7F1EF769CE045F382693E954C164E9A"
+                                        type: "item"
+                                        title: "D\u00e9couvrir mcw-bridges-3.1.0-mc1.18.2forge"
+                                        icon: {
+                                                id: "mcwbridges:acacia_bridge_pier"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "mcwbridges:acacia_bridge_pier"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "B30BF4F483804FF9AA44C6411276A86D"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 276.0d
+                        y: 2.0d
+                        id: "2ABF41583BE54B3597564EC8C81BC14A"
+                        tasks: [
+                                {
+                                        id: "D05B43AFFC3645DA9A01043AEA0B6C09"
+                                        type: "item"
+                                        title: "Approfondir mcw-bridges-3.1.0-mc1.18.2forge"
+                                        icon: {
+                                                id: "mcwbridges:acacia_log_bridge_middle"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "mcwbridges:acacia_log_bridge_middle"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "F7450BA4228D46C995EA6D29B193982F"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "4E6726814C45424FA1E45229426F7E72"
+                        ]
+                },
+                {
+                        x: 276.0d
+                        y: 4.0d
+                        id: "0E61C6F130F3468597744E548E44EA47"
+                        tasks: [
+                                {
+                                        id: "CF171874431C499D9DD153253683BF1E"
+                                        type: "item"
+                                        title: "Ma\u00eetriser mcw-bridges-3.1.0-mc1.18.2forge"
+                                        icon: {
+                                                id: "mcwbridges:acacia_log_bridge_stair"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "mcwbridges:acacia_log_bridge_stair"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "08F0171315E14A56B53879E10CEE2429"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "2ABF41583BE54B3597564EC8C81BC14A"
+                        ]
+                },
+                {
+                        x: 280.0d
+                        y: 0.0d
+                        id: "7C344A265F3A48FF83A5912D4CDCBD8B"
+                        tasks: [
+                                {
+                                        id: "CA7970FC9F5A4F9C98BB7DEAD5BFD0A2"
+                                        type: "item"
+                                        title: "D\u00e9couvrir mcw-doors-1.1.2-mc1.18.2forge"
+                                        icon: {
+                                                id: "mcwdoors:acacia_bamboo_door"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "mcwdoors:acacia_bamboo_door"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "72C0AB2DAA0B4C35B00BF66A7C0E3ACD"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 280.0d
+                        y: 2.0d
+                        id: "33D5C10244F243C5BF9F60FBE7B71BE3"
+                        tasks: [
+                                {
+                                        id: "41CAC395143F4554861757CEE5A034A7"
+                                        type: "item"
+                                        title: "Approfondir mcw-doors-1.1.2-mc1.18.2forge"
+                                        icon: {
+                                                id: "mcwdoors:acacia_bark_glass_door"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "mcwdoors:acacia_bark_glass_door"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "E87A0FC1D7954312ABEC0008FA467E3C"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "7C344A265F3A48FF83A5912D4CDCBD8B"
+                        ]
+                },
+                {
+                        x: 280.0d
+                        y: 4.0d
+                        id: "6E41A4A85B99462DA0E4904B05A37FC7"
+                        tasks: [
+                                {
+                                        id: "7AAC1E921A7C4CEB8E89596DDCDB7A2B"
+                                        type: "item"
+                                        title: "Ma\u00eetriser mcw-doors-1.1.2-mc1.18.2forge"
+                                        icon: {
+                                                id: "mcwdoors:acacia_barn_door"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "mcwdoors:acacia_barn_door"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "7747E8FB91EA4266AE5D701050E34DA9"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "33D5C10244F243C5BF9F60FBE7B71BE3"
+                        ]
+                },
+                {
+                        x: 284.0d
+                        y: 0.0d
+                        id: "197AD02C236A4EABADA7F54931ECC405"
+                        tasks: [
+                                {
+                                        id: "E4A85288668D40B9ABEA16D0D788BEBF"
+                                        type: "item"
+                                        title: "D\u00e9couvrir mcw-fences-1.2.0-1.18.2forge"
+                                        icon: {
+                                                id: "mcwfences:acacia_curved_gate"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "mcwfences:acacia_curved_gate"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "9BED7AC65D0E4FD59D8BF0D0D4F281A4"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 284.0d
+                        y: 2.0d
+                        id: "9DB3344F490D46C88C0B55FBB5021884"
+                        tasks: [
+                                {
+                                        id: "DAACBCBC01804F0C90E789316B60C48C"
+                                        type: "item"
+                                        title: "Approfondir mcw-fences-1.2.0-1.18.2forge"
+                                        icon: {
+                                                id: "mcwfences:acacia_hedge"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "mcwfences:acacia_hedge"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "947C34122B7C4FDBBFB9A2CBD14B0921"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "197AD02C236A4EABADA7F54931ECC405"
+                        ]
+                },
+                {
+                        x: 284.0d
+                        y: 4.0d
+                        id: "3E595C7F0F8347B581FB8AB0FFC71448"
+                        tasks: [
+                                {
+                                        id: "206EEE7E9EFE433896D8582D2C20F67D"
+                                        type: "item"
+                                        title: "Ma\u00eetriser mcw-fences-1.2.0-1.18.2forge"
+                                        icon: {
+                                                id: "mcwfences:acacia_highley_gate"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "mcwfences:acacia_highley_gate"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "66548D39A96446EFBA0CF670144C2710"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "9DB3344F490D46C88C0B55FBB5021884"
+                        ]
+                },
+                {
+                        x: 288.0d
+                        y: 0.0d
+                        id: "08D89A61B2A2474087324B4565FF1F9E"
+                        tasks: [
+                                {
+                                        id: "4CAA37B5A61D4149A643D206952D1713"
+                                        type: "item"
+                                        title: "D\u00e9couvrir mcw-furniture-3.3.0-mc1.18.2forge"
+                                        icon: {
+                                                id: "mcwfurnitures:acacia_bookshelf"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "mcwfurnitures:acacia_bookshelf"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "9F7790C874C041AD8FB3E03E4475194B"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 288.0d
+                        y: 2.0d
+                        id: "1DB96B79BB7B42319EDD9A0448CC6A45"
+                        tasks: [
+                                {
+                                        id: "9526DB59CDE3453A8C7F9A5AECF2283A"
+                                        type: "item"
+                                        title: "Approfondir mcw-furniture-3.3.0-mc1.18.2forge"
+                                        icon: {
+                                                id: "mcwfurnitures:acacia_bookshelf_cupboard"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "mcwfurnitures:acacia_bookshelf_cupboard"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "194E41271C254BF0A8C51926E0CAC0A3"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "08D89A61B2A2474087324B4565FF1F9E"
+                        ]
+                },
+                {
+                        x: 288.0d
+                        y: 4.0d
+                        id: "508E0A29E3C44F75B36F986FEB0A925F"
+                        tasks: [
+                                {
+                                        id: "B0BC00415356455B9BB283C49341CE76"
+                                        type: "item"
+                                        title: "Ma\u00eetriser mcw-furniture-3.3.0-mc1.18.2forge"
+                                        icon: {
+                                                id: "mcwfurnitures:acacia_bookshelf_drawer"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "mcwfurnitures:acacia_bookshelf_drawer"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "F6475B28FDEA48D19DC53157F67D35DC"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "1DB96B79BB7B42319EDD9A0448CC6A45"
+                        ]
+                },
+                {
+                        x: 292.0d
+                        y: 0.0d
+                        id: "83C2F14549384601B518BB1E6B96F25D"
+                        tasks: [
+                                {
+                                        id: "BE439AF54EB24DD9A3F7F590F7EA4B98"
+                                        type: "item"
+                                        title: "D\u00e9couvrir mcw-holidays-1.1.0-mc1.18.2forge"
+                                        icon: {
+                                                id: "mcwholidays:bat_awake"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "mcwholidays:bat_awake"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "43397D1221F941EC94C065AEB8C666F6"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 292.0d
+                        y: 2.0d
+                        id: "1E661F2123F740618402F2B95E21079A"
+                        tasks: [
+                                {
+                                        id: "AC174C79EE1A42288D4C92EB158B033D"
+                                        type: "item"
+                                        title: "Approfondir mcw-holidays-1.1.0-mc1.18.2forge"
+                                        icon: {
+                                                id: "mcwholidays:bat_doormat"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "mcwholidays:bat_doormat"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "BB010BFB13884A12AA22D2EA2FDA5D8D"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "83C2F14549384601B518BB1E6B96F25D"
+                        ]
+                },
+                {
+                        x: 292.0d
+                        y: 4.0d
+                        id: "5F2C3C6C13F6413B82323BF684EFD749"
+                        tasks: [
+                                {
+                                        id: "C73981804C614F47AF7AA8FFAF31067F"
+                                        type: "item"
+                                        title: "Ma\u00eetriser mcw-holidays-1.1.0-mc1.18.2forge"
+                                        icon: {
+                                                id: "mcwholidays:bat_sleeping"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "mcwholidays:bat_sleeping"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "4E441DA6FE8B46008C8B1CFFF95F0F6E"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "1E661F2123F740618402F2B95E21079A"
+                        ]
+                },
+                {
+                        x: 296.0d
+                        y: 0.0d
+                        id: "7558DF1A8B1840CE8A82D099A4D5700F"
+                        tasks: [
+                                {
+                                        id: "12595130DA374FB78090D1599F7289F8"
+                                        type: "item"
+                                        title: "D\u00e9couvrir mcw-lights-1.1.2-mc1.18.2forge"
+                                        icon: {
+                                                id: "mcwlights:acacia_ceiling_fan_light"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "mcwlights:acacia_ceiling_fan_light"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "ABC87ACB2F5C4D3290BDB6BEFD9F84CC"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 296.0d
+                        y: 2.0d
+                        id: "68990048D3034290847B9832F4C10889"
+                        tasks: [
+                                {
+                                        id: "ADB6269F5426484E89A840FA0A7A7C61"
+                                        type: "item"
+                                        title: "Approfondir mcw-lights-1.1.2-mc1.18.2forge"
+                                        icon: {
+                                                id: "mcwlights:acacia_tiki_torch"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "mcwlights:acacia_tiki_torch"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "EBEA4E3905D0468AA756A092FE2AE7E3"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "7558DF1A8B1840CE8A82D099A4D5700F"
+                        ]
+                },
+                {
+                        x: 296.0d
+                        y: 4.0d
+                        id: "91E81CCF9C534BFFBDED825E462014D2"
+                        tasks: [
+                                {
+                                        id: "1EF3FAF5D57E4967A58F4DEB80758225"
+                                        type: "item"
+                                        title: "Ma\u00eetriser mcw-lights-1.1.2-mc1.18.2forge"
+                                        icon: {
+                                                id: "mcwlights:bamboo_tiki_torch"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "mcwlights:bamboo_tiki_torch"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "B8AA4BD9F94B4EC79BB67730657DBB2D"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "68990048D3034290847B9832F4C10889"
+                        ]
+                },
+                {
+                        x: 300.0d
+                        y: 0.0d
+                        id: "D369D13D752F439FBC95EF4CADBBC60A"
+                        tasks: [
+                                {
+                                        id: "63C1C9B3390348DA849379EA1F97F3A9"
+                                        type: "item"
+                                        title: "D\u00e9couvrir mcw-paths-1.1.0forge-mc1.18.2"
+                                        icon: {
+                                                id: "mcwpaths:acacia_planks_path"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "mcwpaths:acacia_planks_path"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "5AD0FFB4BC964AB594ABFFCC8EA7CCD7"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 300.0d
+                        y: 2.0d
+                        id: "B4C840ED4F434F3EBBA0A9D360CC149C"
+                        tasks: [
+                                {
+                                        id: "664CB3ACC6234092A9E12FA05F2C58E1"
+                                        type: "item"
+                                        title: "Approfondir mcw-paths-1.1.0forge-mc1.18.2"
+                                        icon: {
+                                                id: "mcwpaths:andesite_basket_weave_paving"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "mcwpaths:andesite_basket_weave_paving"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "B01AD5257F9648A6A35D73131AD407B8"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "D369D13D752F439FBC95EF4CADBBC60A"
+                        ]
+                },
+                {
+                        x: 300.0d
+                        y: 4.0d
+                        id: "82AFF0B680A74D96B2BCE59309FB9A6A"
+                        tasks: [
+                                {
+                                        id: "16A366B79C264876B59987A219B002FD"
+                                        type: "item"
+                                        title: "Ma\u00eetriser mcw-paths-1.1.0forge-mc1.18.2"
+                                        icon: {
+                                                id: "mcwpaths:andesite_clover_paving"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "mcwpaths:andesite_clover_paving"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "4CE8337AFEAE4182B8C14D9C4C0A11EC"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "B4C840ED4F434F3EBBA0A9D360CC149C"
+                        ]
+                },
+                {
+                        x: 304.0d
+                        y: 0.0d
+                        id: "07B89BE8123041D6B3FB375D493B8BBE"
+                        tasks: [
+                                {
+                                        id: "77899227C5074D7AB5406DBE99D2A44F"
+                                        type: "item"
+                                        title: "D\u00e9couvrir mcw-roofs-2.3.2-mc1.18.2forge"
+                                        icon: {
+                                                id: "mcwroofs:acacia_attic_roof"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "mcwroofs:acacia_attic_roof"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "6438E85271174D8F8EC2A99BBBE384F2"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 304.0d
+                        y: 2.0d
+                        id: "F3782FF22F4D4BADBF91BEE5828FE7D2"
+                        tasks: [
+                                {
+                                        id: "B117D38770FC4E05A8993BB26479935A"
+                                        type: "item"
+                                        title: "Approfondir mcw-roofs-2.3.2-mc1.18.2forge"
+                                        icon: {
+                                                id: "mcwroofs:acacia_lower_roof"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "mcwroofs:acacia_lower_roof"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "F2C3B974DED842E08E0E5078D08E5DF6"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "07B89BE8123041D6B3FB375D493B8BBE"
+                        ]
+                },
+                {
+                        x: 304.0d
+                        y: 4.0d
+                        id: "9F6D9C9A3FBE40DBB000B1E033A96BB9"
+                        tasks: [
+                                {
+                                        id: "F3FF4511F7D84F1AB7544E7B966CEFA4"
+                                        type: "item"
+                                        title: "Ma\u00eetriser mcw-roofs-2.3.2-mc1.18.2forge"
+                                        icon: {
+                                                id: "mcwroofs:acacia_planks_attic_roof"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "mcwroofs:acacia_planks_attic_roof"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "7D3CA2A9FC294D6C80B51DFE4F96C775"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "F3782FF22F4D4BADBF91BEE5828FE7D2"
+                        ]
+                },
+                {
+                        x: 308.0d
+                        y: 0.0d
+                        id: "3DEBBFDDC9944508814653C660616018"
+                        tasks: [
+                                {
+                                        id: "EB681F23ADB74D998CB97D9E15AC1012"
+                                        type: "item"
+                                        title: "D\u00e9couvrir mcw-trapdoors-1.1.4-mc1.18.2forge"
+                                        icon: {
+                                                id: "mcwtrpdoors:acacia_bamboo_trapdoor"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "mcwtrpdoors:acacia_bamboo_trapdoor"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "F8394A40EE784674BC9D9E9F2351BE23"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 308.0d
+                        y: 2.0d
+                        id: "3CFF8B1E3A8F4098B01FDF7A79EB97F1"
+                        tasks: [
+                                {
+                                        id: "612AEB62C16A4E4EA094147F365747B0"
+                                        type: "item"
+                                        title: "Approfondir mcw-trapdoors-1.1.4-mc1.18.2forge"
+                                        icon: {
+                                                id: "mcwtrpdoors:acacia_bark_trapdoor"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "mcwtrpdoors:acacia_bark_trapdoor"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "14933967FD544822BEBFA6E3FBF7838A"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "3DEBBFDDC9944508814653C660616018"
+                        ]
+                },
+                {
+                        x: 308.0d
+                        y: 4.0d
+                        id: "A00F27342FD34442896F72979C02D1A1"
+                        tasks: [
+                                {
+                                        id: "6F0C2EACA39D4A32B3E1DE49EFAB72A3"
+                                        type: "item"
+                                        title: "Ma\u00eetriser mcw-trapdoors-1.1.4-mc1.18.2forge"
+                                        icon: {
+                                                id: "mcwtrpdoors:acacia_barn_trapdoor"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "mcwtrpdoors:acacia_barn_trapdoor"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "172E14024385405684E29CCD87CE997C"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "3CFF8B1E3A8F4098B01FDF7A79EB97F1"
+                        ]
+                },
+                {
+                        x: 312.0d
+                        y: 0.0d
+                        id: "7D5548963E8B4EEF914BE286DBAF96E8"
+                        tasks: [
+                                {
+                                        id: "26B66854059F4023AD31512B41BA7E12"
+                                        type: "item"
+                                        title: "D\u00e9couvrir mcw-windows-2.3.0-mc1.18.2forge"
+                                        icon: {
+                                                id: "mcwwindows:acacia_blinds"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "mcwwindows:acacia_blinds"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "9282C88533454514987C5BC94B07E5DF"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 312.0d
+                        y: 2.0d
+                        id: "986790A2B33D44618C375B13CDE658C3"
+                        tasks: [
+                                {
+                                        id: "0B2D65D336794F059519B6EF5C7C8A23"
+                                        type: "item"
+                                        title: "Approfondir mcw-windows-2.3.0-mc1.18.2forge"
+                                        icon: {
+                                                id: "mcwwindows:acacia_curtain_rod"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "mcwwindows:acacia_curtain_rod"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "014A305765904B758614FB849C165D35"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "7D5548963E8B4EEF914BE286DBAF96E8"
+                        ]
+                },
+                {
+                        x: 312.0d
+                        y: 4.0d
+                        id: "DECA4BC8448644958C2680622E566B5C"
+                        tasks: [
+                                {
+                                        id: "7136369C1C6B4C1D923C62AE590446D5"
+                                        type: "item"
+                                        title: "Ma\u00eetriser mcw-windows-2.3.0-mc1.18.2forge"
+                                        icon: {
+                                                id: "mcwwindows:acacia_four_window"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "mcwwindows:acacia_four_window"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "5A593B2BACAD452FA0BD44A4E9546B95"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "986790A2B33D44618C375B13CDE658C3"
+                        ]
+                },
+                {
+                        x: 316.0d
+                        y: 0.0d
+                        id: "138CBBEEECDF40F9B82EC0D46AD89523"
+                        tasks: [
+                                {
+                                        id: "FFB3F3D5FF3146CEB25E5EB59C16988C"
+                                        type: "item"
+                                        title: "D\u00e9couvrir mob_grinding_utils-1.18.2-0.4.50"
+                                        icon: {
+                                                id: "mob_grinding_utils:absorption_hopper"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "mob_grinding_utils:absorption_hopper"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "887A53FD33AE4A5DAFCACE6197433FB1"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 316.0d
+                        y: 2.0d
+                        id: "12997CE60F0A457593F22FCB082DEE1D"
+                        tasks: [
+                                {
+                                        id: "CC8F327A87554C7EA2C82F7A58E94D70"
+                                        type: "item"
+                                        title: "Approfondir mob_grinding_utils-1.18.2-0.4.50"
+                                        icon: {
+                                                id: "mob_grinding_utils:absorption_upgrade"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "mob_grinding_utils:absorption_upgrade"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "5CDDE320535F4CC09BFEAF9B917FC26D"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "138CBBEEECDF40F9B82EC0D46AD89523"
+                        ]
+                },
+                {
+                        x: 316.0d
+                        y: 4.0d
+                        id: "8B02B932797647498C5CED8CFA024BB4"
+                        tasks: [
+                                {
+                                        id: "4D79EE08A78B4DE5AC23A96F48B9F539"
+                                        type: "item"
+                                        title: "Ma\u00eetriser mob_grinding_utils-1.18.2-0.4.50"
+                                        icon: {
+                                                id: "mob_grinding_utils:dark_oak_stone"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "mob_grinding_utils:dark_oak_stone"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "660FD2525F7F4CD098ED928F658EAE14"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "12997CE60F0A457593F22FCB082DEE1D"
+                        ]
+                },
+                {
+                        x: 320.0d
+                        y: 0.0d
+                        id: "106C82B1510F4CCAB7399AFD43A041B9"
+                        tasks: [
+                                {
+                                        id: "234864D528CB4F06A10A2BFC9488959E"
+                                        type: "item"
+                                        title: "D\u00e9couvrir mobcatcher-1.18.2-4.0.1"
+                                        icon: {
+                                                id: "mobcatcher:net"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "mobcatcher:net"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "F5A1266176A34D5886B89D2FEE3980E0"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 320.0d
+                        y: 2.0d
+                        id: "ECED41BB4D9D4420AF167D2EFCD45C58"
+                        tasks: [
+                                {
+                                        id: "97BF874B4F0342AB8BCDCDCC749EEB6B"
+                                        type: "item"
+                                        title: "Approfondir mobcatcher-1.18.2-4.0.1"
+                                        icon: {
+                                                id: "mobcatcher:net_launcher"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "mobcatcher:net_launcher"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "868C9DD337D64DCB86A58C994B21E93C"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "106C82B1510F4CCAB7399AFD43A041B9"
+                        ]
+                },
+                {
+                        x: 324.0d
+                        y: 0.0d
+                        id: "21CDBBC215E647A5BFA026DFF51A6D2C"
+                        tasks: [
+                                {
+                                        id: "D26C1D72E2F64DF282E72CDC90D96188"
+                                        type: "item"
+                                        title: "D\u00e9couvrir nfm-2022.10.27-1.18.2"
+                                        icon: {
+                                                id: "nfm:black_bar_stool"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "nfm:black_bar_stool"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "F3B33BBCD8EF48EF9FAE471C96E3430E"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 324.0d
+                        y: 2.0d
+                        id: "F5830776836540F89DC938B76D93B3C8"
+                        tasks: [
+                                {
+                                        id: "66C6C41E99164EB8BFC4823B79D7813D"
+                                        type: "item"
+                                        title: "Approfondir nfm-2022.10.27-1.18.2"
+                                        icon: {
+                                                id: "nfm:black_modern_bedside_cabinet"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "nfm:black_modern_bedside_cabinet"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "6569618BCA3A4FFFA5D4FD6E8FF62C58"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "21CDBBC215E647A5BFA026DFF51A6D2C"
+                        ]
+                },
+                {
+                        x: 324.0d
+                        y: 4.0d
+                        id: "76C3340395214FE08F95BB484D88327D"
+                        tasks: [
+                                {
+                                        id: "2332537048B14F69A10F5FC4C1802299"
+                                        type: "item"
+                                        title: "Ma\u00eetriser nfm-2022.10.27-1.18.2"
+                                        icon: {
+                                                id: "nfm:black_modern_cabinet"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "nfm:black_modern_cabinet"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "5C67575935DC4222B46AF51C65503E27"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "F5830776836540F89DC938B76D93B3C8"
+                        ]
+                },
+                {
+                        x: 328.0d
+                        y: 0.0d
+                        id: "D86556AA090F49AFB50F721898E23D4F"
+                        tasks: [
+                                {
+                                        id: "B55FD092EDBB4353B0D58EF9A9D93664"
+                                        type: "item"
+                                        title: "D\u00e9couvrir obscure_api-10"
+                                        icon: {
+                                                id: "obscure_api:astral_dust"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "obscure_api:astral_dust"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "11F845635532413DB8F3145BEB5D1356"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 328.0d
+                        y: 2.0d
+                        id: "FF31B8DFE492489B927D392A790811FC"
+                        tasks: [
+                                {
+                                        id: "FE1EE35396524E29A03DBAE0520F7937"
+                                        type: "item"
+                                        title: "Approfondir obscure_api-10"
+                                        icon: {
+                                                id: "obscure_api:obscure_book"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "obscure_api:obscure_book"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "F603EE3D57F848E7A778680D2786AB3C"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "D86556AA090F49AFB50F721898E23D4F"
+                        ]
+                },
+                {
+                        x: 328.0d
+                        y: 4.0d
+                        id: "B54E2405203B44479AB4A539D657DA63"
+                        tasks: [
+                                {
+                                        id: "A4F1094D258344958246CD530B6EA932"
+                                        type: "item"
+                                        title: "Ma\u00eetriser obscure_api-10"
+                                        icon: {
+                                                id: "obscure_api:vial_of_knowledge"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "obscure_api:vial_of_knowledge"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "FC2F14D74EA849F4A2FF430F91136615"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "FF31B8DFE492489B927D392A790811FC"
+                        ]
+                },
+                {
+                        x: 332.0d
+                        y: 0.0d
+                        id: "6A593EF60193461E825F271F6FCFA749"
+                        tasks: [
+                                {
+                                        id: "0736DB5145D741599FE9C4DD33549DA8"
+                                        type: "item"
+                                        title: "D\u00e9couvrir oceanworld-1.0.7"
+                                        icon: {
+                                                id: "oceanworld:black_brick"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "oceanworld:black_brick"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "B2539C27C6A94D479864D3444F95DB8A"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 332.0d
+                        y: 2.0d
+                        id: "B90AA9772D0F49AA8F78E7CD6993179A"
+                        tasks: [
+                                {
+                                        id: "7757E28BB6994EA89433CB99662C0B86"
+                                        type: "item"
+                                        title: "Approfondir oceanworld-1.0.7"
+                                        icon: {
+                                                id: "oceanworld:black_brick_slab"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "oceanworld:black_brick_slab"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "1DF69219B2A847D18ECC607DDA3FD63B"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "6A593EF60193461E825F271F6FCFA749"
+                        ]
+                },
+                {
+                        x: 332.0d
+                        y: 4.0d
+                        id: "457E3AF2E27D479D8E8260E73C5B990F"
+                        tasks: [
+                                {
+                                        id: "2B8615C6573E432897BBBF3E19D299EB"
+                                        type: "item"
+                                        title: "Ma\u00eetriser oceanworld-1.0.7"
+                                        icon: {
+                                                id: "oceanworld:black_brick_stairs"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "oceanworld:black_brick_stairs"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "87B4E42344E34B0FA7369E56D035798C"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "B90AA9772D0F49AA8F78E7CD6993179A"
+                        ]
+                },
+                {
+                        x: 336.0d
+                        y: 0.0d
+                        id: "18842CB9C1C445A99EA849649227AC0B"
+                        tasks: [
+                                {
+                                        id: "1AA9B74D597547C399340823203CB582"
+                                        type: "item"
+                                        title: "D\u00e9couvrir randomium-1.18.2-1.9"
+                                        icon: {
+                                                id: "randomium:any_item"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "randomium:any_item"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "1D158ACA18AE4EC0B6E9926D7082D158"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 336.0d
+                        y: 2.0d
+                        id: "E06409153F62405A82E0F5765546FAC6"
+                        tasks: [
+                                {
+                                        id: "AE73254AF1C842E4B0FA00104FE9C1CC"
+                                        type: "item"
+                                        title: "Approfondir randomium-1.18.2-1.9"
+                                        icon: {
+                                                id: "randomium:randomium"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "randomium:randomium"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "47AAFBD0A10B4ECCA5C7E41E385013E0"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "18842CB9C1C445A99EA849649227AC0B"
+                        ]
+                },
+                {
+                        x: 336.0d
+                        y: 4.0d
+                        id: "31157F24DF2D44D7A8B246095DB0FA61"
+                        tasks: [
+                                {
+                                        id: "AD8541A5810E44749316B3B00F4AE968"
+                                        type: "item"
+                                        title: "Ma\u00eetriser randomium-1.18.2-1.9"
+                                        icon: {
+                                                id: "randomium:randomium_ore"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "randomium:randomium_ore"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "E4ED37EDF35942399829D0E8DEBF3549"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "E06409153F62405A82E0F5765546FAC6"
+                        ]
+                },
+                {
+                        x: 340.0d
+                        y: 0.0d
+                        id: "CCEDB724BFE64523925F53FB4C18FAE1"
+                        tasks: [
+                                {
+                                        id: "DBA32C6406474FF6BF603CD48D938BB9"
+                                        type: "item"
+                                        title: "D\u00e9couvrir refinedstorage-1.10.6"
+                                        icon: {
+                                                id: "refinedstorage:1024k_fluid_storage_block"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "refinedstorage:1024k_fluid_storage_block"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "62657863C87E4BA6B64B8FD699523788"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 340.0d
+                        y: 2.0d
+                        id: "649BA8A253174501A3E9DA7AB52A1920"
+                        tasks: [
+                                {
+                                        id: "BA349A5F40584328A2CC540C4A739620"
+                                        type: "item"
+                                        title: "Approfondir refinedstorage-1.10.6"
+                                        icon: {
+                                                id: "refinedstorage:1024k_fluid_storage_disk"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "refinedstorage:1024k_fluid_storage_disk"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "592A3549372548ECA99401C3F0CE4267"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "CCEDB724BFE64523925F53FB4C18FAE1"
+                        ]
+                },
+                {
+                        x: 340.0d
+                        y: 4.0d
+                        id: "71518F7B8CC147A6BC4FFE34BD9AB847"
+                        tasks: [
+                                {
+                                        id: "C4531F3DA66B406E96CAFB1D2DBB6941"
+                                        type: "item"
+                                        title: "Ma\u00eetriser refinedstorage-1.10.6"
+                                        icon: {
+                                                id: "refinedstorage:1024k_fluid_storage_part"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "refinedstorage:1024k_fluid_storage_part"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "094FF2BBFD9D4D448C7E74077F6A16F7"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "649BA8A253174501A3E9DA7AB52A1920"
+                        ]
+                },
+                {
+                        x: 344.0d
+                        y: 0.0d
+                        id: "BC63D05E8D7143599F80296143C18764"
+                        tasks: [
+                                {
+                                        id: "1A7CE9A7873749768B758138D13D52D0"
+                                        type: "item"
+                                        title: "D\u00e9couvrir refinedstorageaddons-0.8.2"
+                                        icon: {
+                                                id: "refinedstorageaddons:creative_wireless_crafting_grid"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "refinedstorageaddons:creative_wireless_crafting_grid"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "027FDAD577EB4ADBB3580705DFA74B22"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 344.0d
+                        y: 2.0d
+                        id: "7E079C976BF14DA7B9375A34DEB9BB30"
+                        tasks: [
+                                {
+                                        id: "0989FC751AEA47D0BD1A9D208041EB15"
+                                        type: "item"
+                                        title: "Approfondir refinedstorageaddons-0.8.2"
+                                        icon: {
+                                                id: "refinedstorageaddons:wireless_crafting_grid"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "refinedstorageaddons:wireless_crafting_grid"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "11F914C139A7436EAD651CF3754EADAA"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "BC63D05E8D7143599F80296143C18764"
+                        ]
+                },
+                {
+                        x: 344.0d
+                        y: 4.0d
+                        id: "ECD5DD4EC4574B1885A6828DD19D6F72"
+                        tasks: [
+                                {
+                                        id: "DCD5AD43DD72494A880EE92B7BA1685F"
+                                        type: "item"
+                                        title: "Ma\u00eetriser refinedstorageaddons-0.8.2"
+                                        icon: {
+                                                id: "refinedstorageaddons:wireless_crafting_grid_connected"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "refinedstorageaddons:wireless_crafting_grid_connected"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "230C4C522961499FA7EDE31A2F88D31C"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "7E079C976BF14DA7B9375A34DEB9BB30"
+                        ]
+                },
+                {
+                        x: 348.0d
+                        y: 0.0d
+                        id: "2B041176C4074EA1A63CD2AE93F2AC07"
+                        tasks: [
+                                {
+                                        id: "7D23465939EA43F0943B82A25396132C"
+                                        type: "item"
+                                        title: "D\u00e9couvrir roadstuff-1.18.2-6.0.2"
+                                        icon: {
+                                                id: "roadstuff:asphalt"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "roadstuff:asphalt"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "24FB3A6E617447B08CED2C7FD001828C"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 348.0d
+                        y: 2.0d
+                        id: "6EF48892AF7F4CA4BF349836B3B56CDE"
+                        tasks: [
+                                {
+                                        id: "DACF747688C54B4C8E004F13EE0A7EA3"
+                                        type: "item"
+                                        title: "Approfondir roadstuff-1.18.2-6.0.2"
+                                        icon: {
+                                                id: "roadstuff:asphalt_pressure_plate"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "roadstuff:asphalt_pressure_plate"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "7FFE7B7F2D554A1C9601EAFAABB2956D"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "2B041176C4074EA1A63CD2AE93F2AC07"
+                        ]
+                },
+                {
+                        x: 348.0d
+                        y: 4.0d
+                        id: "3671599BEC3E4D869915E0B88A6D2E8E"
+                        tasks: [
+                                {
+                                        id: "80DE568EEAD348D988C8B16FF2F0413D"
+                                        type: "item"
+                                        title: "Ma\u00eetriser roadstuff-1.18.2-6.0.2"
+                                        icon: {
+                                                id: "roadstuff:asphalt_slab"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "roadstuff:asphalt_slab"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "09E3D5783A5C481881ADC87CC7A30A4D"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "6EF48892AF7F4CA4BF349836B3B56CDE"
+                        ]
+                },
+                {
+                        x: 352.0d
+                        y: 0.0d
+                        id: "997649ABC0A24F8E959E5FB6D5928C32"
+                        tasks: [
+                                {
+                                        id: "FEF825D960D94AD5B4FC9AC7564CEC03"
+                                        type: "item"
+                                        title: "D\u00e9couvrir rsgauges-1.18.2-1.2.18"
+                                        icon: {
+                                                id: "rsgauges:arrow_target"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "rsgauges:arrow_target"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "03183E77944B478E80F4AE008EDCEDA1"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 352.0d
+                        y: 2.0d
+                        id: "9FBE195C4C6542829226FF7A93F3467C"
+                        tasks: [
+                                {
+                                        id: "8257CDEA87BF40FE94EF39A6ED7369B5"
+                                        type: "item"
+                                        title: "Approfondir rsgauges-1.18.2-1.2.18"
+                                        icon: {
+                                                id: "rsgauges:door_sensor_switch"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "rsgauges:door_sensor_switch"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "3F2767B2C3E24611995BBF4DD4479A81"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "997649ABC0A24F8E959E5FB6D5928C32"
+                        ]
+                },
+                {
+                        x: 352.0d
+                        y: 4.0d
+                        id: "4FE303D7EC7542D99FDBD828FA475098"
+                        tasks: [
+                                {
+                                        id: "BD33723E355E44428FF8C69E2EC8CBE6"
+                                        type: "item"
+                                        title: "Ma\u00eetriser rsgauges-1.18.2-1.2.18"
+                                        icon: {
+                                                id: "rsgauges:elevator_button"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "rsgauges:elevator_button"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "9185002868A049DCAF97CD4223B2A9FD"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "9FBE195C4C6542829226FF7A93F3467C"
+                        ]
+                },
+                {
+                        x: 356.0d
+                        y: 0.0d
+                        id: "D4CF6DE2ED854453B5828C0B29DEB85E"
+                        tasks: [
+                                {
+                                        id: "540C39FB44214479A3088B6B72B4857D"
+                                        type: "item"
+                                        title: "D\u00e9couvrir signtastic-1.18-1.0.0"
+                                        icon: {
+                                                id: "signtastic:block_sign"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "signtastic:block_sign"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "6D8196EDD03547F385748445C12538FE"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 356.0d
+                        y: 2.0d
+                        id: "FEE61327A4034952B9CC4DE475B664D3"
+                        tasks: [
+                                {
+                                        id: "D54EED890AEC4382B46A4BD1DC74BBA7"
+                                        type: "item"
+                                        title: "Approfondir signtastic-1.18-1.0.0"
+                                        icon: {
+                                                id: "signtastic:sign_configurator"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "signtastic:sign_configurator"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "77EBB57F850B4AFB9FBB820BCF04ACD8"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "D4CF6DE2ED854453B5828C0B29DEB85E"
+                        ]
+                },
+                {
+                        x: 356.0d
+                        y: 4.0d
+                        id: "F5DAC91224F9418C98E8B8A0D079A162"
+                        tasks: [
+                                {
+                                        id: "3331219AFE6E467796CA305A7B44646A"
+                                        type: "item"
+                                        title: "Ma\u00eetriser signtastic-1.18-1.0.0"
+                                        icon: {
+                                                id: "signtastic:slab_sign"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "signtastic:slab_sign"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "87EFA358A67E4FBAB639AE2411556BFD"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "FEE61327A4034952B9CC4DE475B664D3"
+                        ]
+                },
+                {
+                        x: 360.0d
+                        y: 0.0d
+                        id: "6CF04D2B5AB74269A60CF29FD6B8C809"
+                        tasks: [
+                                {
+                                        id: "80AB51B4C2AB48B1AE32CF347E349E9B"
+                                        type: "item"
+                                        title: "D\u00e9couvrir simplemagnets-1.1.12-forge-mc1.18"
+                                        icon: {
+                                                id: "simplemagnets:advanced_demagnetization_coil"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "simplemagnets:advanced_demagnetization_coil"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "A43612E634EB4EE586BBD27362E9C51C"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 360.0d
+                        y: 2.0d
+                        id: "B337766DC7D541568C4BA322C80F008E"
+                        tasks: [
+                                {
+                                        id: "E88D4286E4374F9E8F21FC3D46787BD9"
+                                        type: "item"
+                                        title: "Approfondir simplemagnets-1.1.12-forge-mc1.18"
+                                        icon: {
+                                                id: "simplemagnets:advancedmagnet"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "simplemagnets:advancedmagnet"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "EC6956C433AF4D6094A683A393CAE36A"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "6CF04D2B5AB74269A60CF29FD6B8C809"
+                        ]
+                },
+                {
+                        x: 360.0d
+                        y: 4.0d
+                        id: "5800F273DB6945E3BF019C1BC7B75E0F"
+                        tasks: [
+                                {
+                                        id: "2AF1A16587C5414AB673BC020E00594D"
+                                        type: "item"
+                                        title: "Ma\u00eetriser simplemagnets-1.1.12-forge-mc1.18"
+                                        icon: {
+                                                id: "simplemagnets:basic_demagnetization_coil"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "simplemagnets:basic_demagnetization_coil"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "679057BDC5894AEFBCF1FCFAD21AC4A2"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "B337766DC7D541568C4BA322C80F008E"
+                        ]
+                },
+                {
+                        x: 364.0d
+                        y: 0.0d
+                        id: "3E0785F3081C40EE917B73D987DFB09B"
+                        tasks: [
+                                {
+                                        id: "50DB26A15AE34E92AAB0E426BB0954E1"
+                                        type: "item"
+                                        title: "D\u00e9couvrir simplylight-1.18.2-1.4.5-build.43"
+                                        icon: {
+                                                id: "simplylight:edge_light"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "simplylight:edge_light"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "50C26240AD1C4BF3920E886C4EB2ACC2"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 364.0d
+                        y: 2.0d
+                        id: "EA3AD4AF433B48D68DB05BF7CFB9D8B9"
+                        tasks: [
+                                {
+                                        id: "11987704B0974523834EAD23D1668919"
+                                        type: "item"
+                                        title: "Approfondir simplylight-1.18.2-1.4.5-build.43"
+                                        icon: {
+                                                id: "simplylight:edge_light_top"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "simplylight:edge_light_top"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "4BC628079881469BB448C48363B85D60"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "3E0785F3081C40EE917B73D987DFB09B"
+                        ]
+                },
+                {
+                        x: 364.0d
+                        y: 4.0d
+                        id: "66008D2E74DC47AD838D136C2F75DB53"
+                        tasks: [
+                                {
+                                        id: "804FC98A9B034D25B0C2667942661570"
+                                        type: "item"
+                                        title: "Ma\u00eetriser simplylight-1.18.2-1.4.5-build.43"
+                                        icon: {
+                                                id: "simplylight:illuminant_black_block"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "simplylight:illuminant_black_block"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "4AB11B6A669942EBA54D3A35C1D75E5F"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "EA3AD4AF433B48D68DB05BF7CFB9D8B9"
+                        ]
+                },
+                {
+                        x: 368.0d
+                        y: 0.0d
+                        id: "E9E00C96F9D44E87B5F8FBE358326059"
+                        tasks: [
+                                {
+                                        id: "2D076E7C497A42698F5A9C329A804659"
+                                        type: "item"
+                                        title: "D\u00e9couvrir structure_gel-1.18.2-2.4.8"
+                                        icon: {
+                                                id: "structure_gel:blue_gel"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "structure_gel:blue_gel"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "164060A1F50A401B9E38BA74A49FBE99"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 368.0d
+                        y: 2.0d
+                        id: "AD23C7EBE303471D8D165562A5A2BB5F"
+                        tasks: [
+                                {
+                                        id: "8F727355811E4E2784725304EE9FE580"
+                                        type: "item"
+                                        title: "Approfondir structure_gel-1.18.2-2.4.8"
+                                        icon: {
+                                                id: "structure_gel:building_tool"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "structure_gel:building_tool"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "A17360A3000B48938E295B2619C8C7BF"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "E9E00C96F9D44E87B5F8FBE358326059"
+                        ]
+                },
+                {
+                        x: 368.0d
+                        y: 4.0d
+                        id: "A65E5768F724452DBC47E7645BB56C9D"
+                        tasks: [
+                                {
+                                        id: "C60A480ACC5741248EA6A9CB29503FDE"
+                                        type: "item"
+                                        title: "Ma\u00eetriser structure_gel-1.18.2-2.4.8"
+                                        icon: {
+                                                id: "structure_gel:building_tool_clear"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "structure_gel:building_tool_clear"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "CD4B0266F3E3461CAC31D1D5233014AB"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "AD23C7EBE303471D8D165562A5A2BB5F"
+                        ]
+                },
+                {
+                        x: 372.0d
+                        y: 0.0d
+                        id: "0D100BA585EA496080000735D240B4D4"
+                        tasks: [
+                                {
+                                        id: "1BA236058A974C569C4A3B3BE93B1081"
+                                        type: "item"
+                                        title: "D\u00e9couvrir tacz-1.18.2-1.1.4-hotfix-all"
+                                        icon: {
+                                                id: "tacz:all_type_creative_ammo_box"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "tacz:all_type_creative_ammo_box"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "6DA569E95EE54D7BA5A3902D756FABEA"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 372.0d
+                        y: 2.0d
+                        id: "AE6DBC89A20C4856BF566B03EB9D047C"
+                        tasks: [
+                                {
+                                        id: "E97DC84A2FD44237B6C8570A755BFA72"
+                                        type: "item"
+                                        title: "Approfondir tacz-1.18.2-1.1.4-hotfix-all"
+                                        icon: {
+                                                id: "tacz:ammo"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "tacz:ammo"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "DA4D0972F6FF4F3480F709A3943C71AB"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "0D100BA585EA496080000735D240B4D4"
+                        ]
+                },
+                {
+                        x: 372.0d
+                        y: 4.0d
+                        id: "84CCA2BC9F0D4F3D8BA152D20185A8E1"
+                        tasks: [
+                                {
+                                        id: "F81EFE6AE088428AAFF954A9691C1D53"
+                                        type: "item"
+                                        title: "Ma\u00eetriser tacz-1.18.2-1.1.4-hotfix-all"
+                                        icon: {
+                                                id: "tacz:ammo_box"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "tacz:ammo_box"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "D52D60790A924EF3B81961F4F0E770EE"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "AE6DBC89A20C4856BF566B03EB9D047C"
+                        ]
+                },
+                {
+                        x: 376.0d
+                        y: 0.0d
+                        id: "7185F9B905644D949DB6E7C649F4A67F"
+                        tasks: [
+                                {
+                                        id: "52107F8BA5E94876A009405D401C03DF"
+                                        type: "item"
+                                        title: "D\u00e9couvrir torchmaster-18.2.1"
+                                        icon: {
+                                                id: "torchmaster:dreadlamp"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "torchmaster:dreadlamp"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "9D2F3808D5E6418B83C2F1F0AD4434CE"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 376.0d
+                        y: 2.0d
+                        id: "F36348E0631D4A98A0CFDA546AF826BA"
+                        tasks: [
+                                {
+                                        id: "073B985289B941509F8DD412D9C8CF57"
+                                        type: "item"
+                                        title: "Approfondir torchmaster-18.2.1"
+                                        icon: {
+                                                id: "torchmaster:feral_flare_lantern"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "torchmaster:feral_flare_lantern"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "30C79E88AF7B4A6F86C133025C7FD68E"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "7185F9B905644D949DB6E7C649F4A67F"
+                        ]
+                },
+                {
+                        x: 376.0d
+                        y: 4.0d
+                        id: "2F3A220312F64DEB9247C612E7CF91A7"
+                        tasks: [
+                                {
+                                        id: "A111F5F30E1A465EAB83F340588D5D94"
+                                        type: "item"
+                                        title: "Ma\u00eetriser torchmaster-18.2.1"
+                                        icon: {
+                                                id: "torchmaster:frozen_pearl"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "torchmaster:frozen_pearl"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "C5EB633F59384E6EA764BE661767A309"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "F36348E0631D4A98A0CFDA546AF826BA"
+                        ]
+                },
+                {
+                        x: 380.0d
+                        y: 0.0d
+                        id: "CFA6C24E4291458B9C7ECFF61BA2B61A"
+                        tasks: [
+                                {
+                                        id: "56214738E99E4FD4B65D1FFF6F0E0C2F"
+                                        type: "item"
+                                        title: "D\u00e9couvrir waterframes-FORGE-mc1.18.2-v2.1.12"
+                                        icon: {
+                                                id: "waterframes:big_tv"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "waterframes:big_tv"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "F72653073843417AABEAE74C6152B6B4"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 380.0d
+                        y: 2.0d
+                        id: "18FF6527A4344382B22CCA833BC8F2C3"
+                        tasks: [
+                                {
+                                        id: "FE953B96977F41DCB7737AC13B005A42"
+                                        type: "item"
+                                        title: "Approfondir waterframes-FORGE-mc1.18.2-v2.1.12"
+                                        icon: {
+                                                id: "waterframes:frame"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "waterframes:frame"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "BEB9710896644342A6EA785CB13FADBE"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "CFA6C24E4291458B9C7ECFF61BA2B61A"
+                        ]
+                },
+                {
+                        x: 380.0d
+                        y: 4.0d
+                        id: "ACB11FB202AD4126A2F56E2B37E1A40B"
+                        tasks: [
+                                {
+                                        id: "55E81C3DB5964167A9EC5737BDE2FDAE"
+                                        type: "item"
+                                        title: "Ma\u00eetriser waterframes-FORGE-mc1.18.2-v2.1.12"
+                                        icon: {
+                                                id: "waterframes:projector"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "waterframes:projector"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "99604CB6B1C548359321AD2663F392BD"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "18FF6527A4344382B22CCA833BC8F2C3"
+                        ]
+                },
+                {
+                        x: 384.0d
+                        y: 0.0d
+                        id: "F746D9162CFB4473AFCF55875AC2AAB6"
+                        tasks: [
+                                {
+                                        id: "309B0DA64E4D4722AC95D0E2242AD6CC"
+                                        type: "item"
+                                        title: "D\u00e9couvrir waystones-forge-1.18.2-10.2.2"
+                                        icon: {
+                                                id: "waystones:attuned_shard"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "waystones:attuned_shard"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "F3BB26834EEA44FF9931A952015B4810"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 384.0d
+                        y: 2.0d
+                        id: "53995E34500A480EA307C01717F89F8C"
+                        tasks: [
+                                {
+                                        id: "11D50B2B687E4813BA3D3707EA48296F"
+                                        type: "item"
+                                        title: "Approfondir waystones-forge-1.18.2-10.2.2"
+                                        icon: {
+                                                id: "waystones:black_sharestone"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "waystones:black_sharestone"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "B0DD0BED56FB408F83A4368CC747902B"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "F746D9162CFB4473AFCF55875AC2AAB6"
+                        ]
+                },
+                {
+                        x: 384.0d
+                        y: 4.0d
+                        id: "98E31D4CC642442BA9736B7EDCDD6BB7"
+                        tasks: [
+                                {
+                                        id: "3EDFF4E0E0F744AE9468343CADEAA754"
+                                        type: "item"
+                                        title: "Ma\u00eetriser waystones-forge-1.18.2-10.2.2"
+                                        icon: {
+                                                id: "waystones:blue_sharestone"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "waystones:blue_sharestone"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "7F67D7B4EE464C3BB95592303085F338"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "53995E34500A480EA307C01717F89F8C"
+                        ]
+                }
+        ]
+}

--- a/Survie/minecraft/config/ftbquests/quests/chapters/mods_tech_gen.snbt
+++ b/Survie/minecraft/config/ftbquests/quests/chapters/mods_tech_gen.snbt
@@ -1,0 +1,303 @@
+{
+        id: "C4114F8D4DEA4300AA19DD0081E31F4F"
+        group: ""
+        order_index: 1
+        filename: "mods_tech_gen"
+        title: "Technologie"
+        icon: {
+                id: "minecraft:redstone"
+                Count: 1b
+        }
+        default_quest_shape: ""
+        default_hide_dependency_lines: false
+        quests: [
+                {
+                        x: 0.0d
+                        y: 0.0d
+                        id: "B5D9DA89739A47A5BA3D51EFBCA29990"
+                        tasks: [
+                                {
+                                        id: "1BC8DBCB5CC3444B9DF2BF5BAC48E725"
+                                        type: "item"
+                                        title: "D\u00e9couvrir ClickMachine-1.18.2-6.0.5"
+                                        icon: {
+                                                id: "clickmachine:auto_clicker"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "clickmachine:auto_clicker"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "6DD14C1B7209422AB8A74B95138CBD25"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 4.0d
+                        y: 0.0d
+                        id: "279CC6ED50A149EAB5B47E82AB617749"
+                        tasks: [
+                                {
+                                        id: "2EACECF65A5F4BEABFBF2B0BC26767B6"
+                                        type: "item"
+                                        title: "D\u00e9couvrir Mekanism-1.18.2-10.2.5.465"
+                                        icon: {
+                                                id: "mekanism:advanced_bin"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "mekanism:advanced_bin"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "B012CDBBCB07433787877BF11435C88D"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 4.0d
+                        y: 2.0d
+                        id: "55C6E3DDD57845AC96F067F0EC47887D"
+                        tasks: [
+                                {
+                                        id: "BC6EDA91A849401BAB494EFA4DDBAD64"
+                                        type: "item"
+                                        title: "Approfondir Mekanism-1.18.2-10.2.5.465"
+                                        icon: {
+                                                id: "mekanism:advanced_bounding_block"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "mekanism:advanced_bounding_block"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "F330D6651E22467D9CD99EED926948BE"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "279CC6ED50A149EAB5B47E82AB617749"
+                        ]
+                },
+                {
+                        x: 4.0d
+                        y: 4.0d
+                        id: "31C560C26A9247FBA1A635F6C91C92FE"
+                        tasks: [
+                                {
+                                        id: "1CBF65E7099341D48BBCE739365FC9DA"
+                                        type: "item"
+                                        title: "Ma\u00eetriser Mekanism-1.18.2-10.2.5.465"
+                                        icon: {
+                                                id: "mekanism:advanced_chemical_tank"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "mekanism:advanced_chemical_tank"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "A802BDD3BAED419E80F8B0050918C083"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "55C6E3DDD57845AC96F067F0EC47887D"
+                        ]
+                },
+                {
+                        x: 8.0d
+                        y: 0.0d
+                        id: "422AD83E57DD4848BDB1407FDDB17361"
+                        tasks: [
+                                {
+                                        id: "24D2BF0754744D80B34876F0B8F25CBD"
+                                        type: "item"
+                                        title: "D\u00e9couvrir MekanismGenerators-1.18.2-10.2.5.465"
+                                        icon: {
+                                                id: "mekanismgenerators:advanced_solar_generator"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "mekanismgenerators:advanced_solar_generator"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "0E386A96DA6C467B8E2C42FABA23059E"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 8.0d
+                        y: 2.0d
+                        id: "5136F0BD82574737AE0577791DEDE30D"
+                        tasks: [
+                                {
+                                        id: "6646975398EA4860B554335CE7E7365D"
+                                        type: "item"
+                                        title: "Approfondir MekanismGenerators-1.18.2-10.2.5.465"
+                                        icon: {
+                                                id: "mekanismgenerators:bio_generator"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "mekanismgenerators:bio_generator"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "7B86AB617D054405B173ADE6CB05529F"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "422AD83E57DD4848BDB1407FDDB17361"
+                        ]
+                },
+                {
+                        x: 8.0d
+                        y: 4.0d
+                        id: "2997FDDEF8B349ECA6EF30F5D17F27DE"
+                        tasks: [
+                                {
+                                        id: "170BB7005479491F8BC4E3771C072CEE"
+                                        type: "item"
+                                        title: "Ma\u00eetriser MekanismGenerators-1.18.2-10.2.5.465"
+                                        icon: {
+                                                id: "mekanismgenerators:bioethanol_bucket"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "mekanismgenerators:bioethanol_bucket"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "7484178D77CE47DBB6587472D7A32A98"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "5136F0BD82574737AE0577791DEDE30D"
+                        ]
+                },
+                {
+                        x: 12.0d
+                        y: 0.0d
+                        id: "8F6EF5DCE3514C9F92F033D8E6692772"
+                        tasks: [
+                                {
+                                        id: "CB948EB52FB842BE89E9DA9E6B0AA02F"
+                                        type: "item"
+                                        title: "D\u00e9couvrir MekanismTools-1.18.2-10.2.5.465"
+                                        icon: {
+                                                id: "mekanismtools:bronze_axe"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "mekanismtools:bronze_axe"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "25E1F41B30D44FD98F789789617B8C22"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 12.0d
+                        y: 2.0d
+                        id: "EEE5009D28AA4172A9D8A55A4CDA9463"
+                        tasks: [
+                                {
+                                        id: "79CE7A3E92D143D4BD62C8095FC9A51A"
+                                        type: "item"
+                                        title: "Approfondir MekanismTools-1.18.2-10.2.5.465"
+                                        icon: {
+                                                id: "mekanismtools:bronze_boots"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "mekanismtools:bronze_boots"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "F9DB2E54962F4C1593DD3EDA77D6EC03"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "8F6EF5DCE3514C9F92F033D8E6692772"
+                        ]
+                },
+                {
+                        x: 12.0d
+                        y: 4.0d
+                        id: "A11399074A3740C2813370937810365C"
+                        tasks: [
+                                {
+                                        id: "8B3AA4A3E9F144B4B36F742017767D91"
+                                        type: "item"
+                                        title: "Ma\u00eetriser MekanismTools-1.18.2-10.2.5.465"
+                                        icon: {
+                                                id: "mekanismtools:bronze_chestplate"
+                                                Count: 1b
+                                        }
+                                        item: {
+                                                id: "mekanismtools:bronze_chestplate"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "D3F14F3EE20347B4904092A37E1B67A6"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "EEE5009D28AA4172A9D8A55A4CDA9463"
+                        ]
+                }
+        ]
+}

--- a/build_mod_quests.py
+++ b/build_mod_quests.py
@@ -1,0 +1,149 @@
+import zipfile, uuid, json, re
+from pathlib import Path
+
+mods_dir = Path('Survie/minecraft/mods')
+chapters_dir = Path('Survie/minecraft/config/ftbquests/quests/chapters')
+
+# Remove existing generated chapters
+for path in chapters_dir.glob('mods_*_gen.snbt'):
+    path.unlink()
+
+# categorization keywords
+categories = {
+    'tech': {
+        'title': 'Technologie',
+        'icon': 'minecraft:redstone',
+        'keywords': ['tech', 'mekanism', 'thermal', 'engineer', 'industrial', 'power', 'factory', 'automation', 'machine', 'energy', 'industrial', 'electric']
+    },
+    'magic': {
+        'title': 'Magie',
+        'icon': 'minecraft:enchanted_book',
+        'keywords': ['magic', 'magie', 'spell', 'arcane', 'wizard', 'botania', 'ars', 'mana', 'apotheosis', 'mystic', 'sorcer', 'enchanted']
+    },
+    'agri': {
+        'title': 'Agriculture',
+        'icon': 'minecraft:wheat',
+        'keywords': ['farm', 'crop', 'agri', 'plant', 'harvest', 'food', 'culinary', 'cuisine']
+    },
+    'explore': {
+        'title': 'Exploration',
+        'icon': 'minecraft:compass',
+        'keywords': ['explor', 'biome', 'dungeon', 'quest', 'adventure', 'aether', 'earth', 'minecolon', 'twilight', 'end', 'nether']
+    },
+    'other': {
+        'title': 'Divers',
+        'icon': 'minecraft:book',
+        'keywords': []
+    }
+}
+
+# helper to classify mod by jar name
+
+def classify(name: str):
+    lname = name.lower()
+    for key, data in categories.items():
+        for kw in data['keywords']:
+            if kw in lname:
+                return key
+    return 'other'
+
+# Build mods data
+mods_by_category = {key: [] for key in categories}
+
+for jar in mods_dir.glob('*.jar'):
+    try:
+        with zipfile.ZipFile(jar) as z:
+            names = z.namelist()
+            modids = {n.split('/')[1] for n in names if n.startswith('assets/')}
+            modids.discard('minecraft'); modids.discard('');
+            if not modids:
+                continue
+            modid = sorted(modids)[0]
+            items = [Path(n).stem for n in names if n.startswith(f'assets/{modid}/models/item/') and n.endswith('.json')]
+            if not items:
+                continue
+            items = sorted(set(items))[:3]
+            modname = jar.stem
+            cat = classify(modname)
+            mods_by_category[cat].append({'modid': modid, 'modname': modname, 'items': items})
+    except zipfile.BadZipFile:
+        pass
+
+# Generate chapters
+for order, (cat_key, data) in enumerate(categories.items(), start=1):
+    mods = mods_by_category[cat_key]
+    if not mods:
+        continue
+    chapter = {
+        'id': uuid.uuid4().hex.upper(),
+        'group': '',
+        'order_index': order,
+        'filename': f'mods_{cat_key}_gen',
+        'title': data['title'],
+        'icon': {'id': data['icon'], 'Count': '1b'},
+        'default_quest_shape': '',
+        'default_hide_dependency_lines': False,
+        'quests': []
+    }
+    for idx, mod in enumerate(sorted(mods, key=lambda m: m['modname'])):
+        x_base = idx * 4
+        prev_id = None
+        for qn, item in enumerate(mod['items'], start=1):
+            q_id = uuid.uuid4().hex.upper()
+            t_id = uuid.uuid4().hex.upper()
+            r_id = uuid.uuid4().hex.upper()
+            quest = {
+                'x': float(x_base),
+                'y': float((qn-1)*2),
+                'id': q_id,
+                'tasks': [{
+                    'id': t_id,
+                    'type': 'item',
+                    'title': ('Découvrir ' if qn==1 else ('Approfondir ' if qn==2 else 'Maîtriser ')) + mod['modname'],
+                    'icon': {'id': f"{mod['modid']}:{item}", 'Count': '1b'},
+                    'item': {'id': f"{mod['modid']}:{item}", 'Count': '1b'}
+                }],
+                'rewards': [{
+                    'id': r_id,
+                    'type': 'xp',
+                    'xp': 100 * qn
+                }]
+            }
+            if prev_id:
+                quest['dependencies'] = [prev_id]
+            chapter['quests'].append(quest)
+            prev_id = q_id
+    # write SNBT
+    def to_snbt(obj, indent=0):
+        sp = '        '
+        if isinstance(obj, dict):
+            if not obj:
+                return '{ }'
+            lines = ['{']
+            for k, v in obj.items():
+                lines.append(f"{sp*(indent+1)}{k}: {to_snbt(v, indent+1)}")
+            lines.append(f"{sp*indent}}}")
+            return '\n'.join(lines)
+        elif isinstance(obj, list):
+            if not obj:
+                return '[]'
+            lines = ['[']
+            for i, v in enumerate(obj):
+                comma = ',' if i < len(obj)-1 else ''
+                lines.append(f"{sp*(indent+1)}{to_snbt(v, indent+1)}{comma}")
+            lines.append(f"{sp*indent}]")
+            return '\n'.join(lines)
+        elif isinstance(obj, bool):
+            return 'true' if obj else 'false'
+        elif isinstance(obj, float):
+            return f"{obj:.1f}d"
+        elif isinstance(obj, int):
+            return str(obj)
+        elif isinstance(obj, str) and obj.endswith('b') and obj[:-1].isdigit():
+            return obj
+        else:
+            return json.dumps(obj)
+
+    snbt = '{\n' + '\n'.join(f"        {k}: {to_snbt(v,1)}" for k,v in chapter.items()) + '\n}\n'
+    out_path = chapters_dir / f"mods_{cat_key}_gen.snbt"
+    out_path.write_text(snbt, encoding='utf-8')


### PR DESCRIPTION
## Summary
- group quests into Technology, Magic, Exploration and Misc chapters
- each quest chain uses real items from its mod instead of generic books

## Testing
- `rg 'minecraft:book' -n Survie/minecraft/config/ftbquests/quests/chapters`
- `python -m py_compile build_mod_quests.py`


------
https://chatgpt.com/codex/tasks/task_e_68c56d422fc48333bf09a36cab21fcf0