### PR TITLE
Add auto-generated quests for mods

### DIFF
--- a/Survie/minecraft/config/ftbquests/quests/chapters/mods_explore_gen.snbt
+++ b/Survie/minecraft/config/ftbquests/quests/chapters/mods_explore_gen.snbt
@@ -1,0 +1,762 @@
+{
+        id: "7F02BD998E124EF9902C082DACB55E5E"
+        group: ""
+        order_index: 4
+        filename: "mods_explore_gen"
+        title: "Exploration"
+        icon: {
+                id: "minecraft:compass"
+                Count: 1b
+        }
+        default_quest_shape: ""
+        default_hide_dependency_lines: false
+        quests: [
+                {
+                        x: 0.0d
+                        y: 0.0d
+                        id: "DD512D738E27458EAFAF8FBC0D59EFC7"
+                        title: "D\u00e9couverte : Beyond Earth"
+                        icon: {
+                                id: "beyond_earth:alien"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "1CC368BC08A84EF0B45D588585907A70"
+                                        type: "item"
+                                        item: {
+                                                id: "beyond_earth:alien"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "6F581A7DDC604781A656F545BB1C55B8"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 0.0d
+                        y: 2.0d
+                        id: "E846A9C538DF4FC7BF7268862818D0B3"
+                        title: "Progression : Beyond Earth"
+                        icon: {
+                                id: "beyond_earth:alien_spawn_egg"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "21FEDDED5AF14927BA6DAB6FB10E5907"
+                                        type: "item"
+                                        item: {
+                                                id: "beyond_earth:alien_spawn_egg"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "FDD0F5C33A7D4D319A8C3480B714B7C0"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "DD512D738E27458EAFAF8FBC0D59EFC7"
+                        ]
+                },
+                {
+                        x: 0.0d
+                        y: 4.0d
+                        id: "A83B13B2079E43E297C9FCB586EAFC05"
+                        title: "Ma\u00eetrise : Beyond Earth"
+                        icon: {
+                                id: "beyond_earth:alien_spit_entity"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "A51AC020DE394326AC7358A66D83F158"
+                                        type: "item"
+                                        item: {
+                                                id: "beyond_earth:alien_spit_entity"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "990A352FBE6A4122B4A5817A7E8166B1"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "E846A9C538DF4FC7BF7268862818D0B3"
+                        ]
+                },
+                {
+                        x: 5.0d
+                        y: 0.0d
+                        id: "3509C94C11D04E30AA08258F3959C183"
+                        title: "D\u00e9couverte : Beyond Earth Giselle Addon"
+                        icon: {
+                                id: "beyond_earth_giselle_addon:advanced_compressor"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "1DCED83CAFFC4803843EA9AFC13A66D3"
+                                        type: "item"
+                                        item: {
+                                                id: "beyond_earth_giselle_addon:advanced_compressor"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "526427B035294FAE9D5F06B2ED91232E"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "A83B13B2079E43E297C9FCB586EAFC05"
+                        ]
+                },
+                {
+                        x: 5.0d
+                        y: 2.0d
+                        id: "68822A0A980B482E93A3F76ABCE401DC"
+                        title: "Progression : Beyond Earth Giselle Addon"
+                        icon: {
+                                id: "beyond_earth_giselle_addon:electric_blast_furnace"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "7BA4FA4C9F53446F95BCB164C38AD395"
+                                        type: "item"
+                                        item: {
+                                                id: "beyond_earth_giselle_addon:electric_blast_furnace"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "B07215016AE14FDCB54D0926EC7650A5"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "3509C94C11D04E30AA08258F3959C183"
+                        ]
+                },
+                {
+                        x: 5.0d
+                        y: 4.0d
+                        id: "ECB803A774C6432DA73116F02BD1A765"
+                        title: "Ma\u00eetrise : Beyond Earth Giselle Addon"
+                        icon: {
+                                id: "beyond_earth_giselle_addon:fuel_loader"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "311F0E3AC67B48B7AF48A921BB8A2229"
+                                        type: "item"
+                                        item: {
+                                                id: "beyond_earth_giselle_addon:fuel_loader"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "A120C4DBCB284EA894F8FA039118D1C1"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "68822A0A980B482E93A3F76ABCE401DC"
+                        ]
+                },
+                {
+                        x: 10.0d
+                        y: 0.0d
+                        id: "B848F1E6F0374B4982054F91A7048228"
+                        title: "D\u00e9couverte : Dungeons Gear"
+                        icon: {
+                                id: "dungeons_gear:anchor"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "DBFBD5310F794175B36374D866623CA9"
+                                        type: "item"
+                                        item: {
+                                                id: "dungeons_gear:anchor"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "CE994B2B4BDC435D8189AE87CE320578"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "ECB803A774C6432DA73116F02BD1A765"
+                        ]
+                },
+                {
+                        x: 10.0d
+                        y: 2.0d
+                        id: "B1F2269FCFE04282A58031F932B751AB"
+                        title: "Progression : Dungeons Gear"
+                        icon: {
+                                id: "dungeons_gear:ancient_bow"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "BE93EE851EB440EB8CE48EA4DA86EB14"
+                                        type: "item"
+                                        item: {
+                                                id: "dungeons_gear:ancient_bow"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "E8F12B9D9F344C4D9760ADF3DF78A005"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "B848F1E6F0374B4982054F91A7048228"
+                        ]
+                },
+                {
+                        x: 10.0d
+                        y: 4.0d
+                        id: "05BFDF67535F45D38A27CDA2489AE351"
+                        title: "Ma\u00eetrise : Dungeons Gear"
+                        icon: {
+                                id: "dungeons_gear:ancient_bow_pulling_0"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "515B5DDE8C89418D9A6981E0BB9A76C4"
+                                        type: "item"
+                                        item: {
+                                                id: "dungeons_gear:ancient_bow_pulling_0"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "C5A85B844798423CA565FF1F77C41C70"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "B1F2269FCFE04282A58031F932B751AB"
+                        ]
+                },
+                {
+                        x: 15.0d
+                        y: 0.0d
+                        id: "CDCB2DF2E5C64F11A04CD588374D0D9B"
+                        title: "D\u00e9couverte : Dungeons Plus"
+                        icon: {
+                                id: "dungeons_plus:frosted_cowl"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "02A775044FD74A648BA16DF77B5CC25D"
+                                        type: "item"
+                                        item: {
+                                                id: "dungeons_plus:frosted_cowl"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "D6E3D4BDD9864725BDFB750A0B807556"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "05BFDF67535F45D38A27CDA2489AE351"
+                        ]
+                },
+                {
+                        x: 15.0d
+                        y: 2.0d
+                        id: "248CFDF8D2E94F23AFBEF00D7137A018"
+                        title: "Progression : Dungeons Plus"
+                        icon: {
+                                id: "dungeons_plus:leviathan_blade"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "B37D82D0EA7F451A9AD2E11AE17766A4"
+                                        type: "item"
+                                        item: {
+                                                id: "dungeons_plus:leviathan_blade"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "25E266C21EE84F8F83C276745017685F"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "CDCB2DF2E5C64F11A04CD588374D0D9B"
+                        ]
+                },
+                {
+                        x: 15.0d
+                        y: 4.0d
+                        id: "C556407B76954A1E8C370EF7B09A2764"
+                        title: "Ma\u00eetrise : Dungeons Plus"
+                        icon: {
+                                id: "dungeons_plus:soul_cannon"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "D409402092A74EE49CB3BCC0571C3E25"
+                                        type: "item"
+                                        item: {
+                                                id: "dungeons_plus:soul_cannon"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "F5E88003336E4371A35F0C6A5952639E"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "248CFDF8D2E94F23AFBEF00D7137A018"
+                        ]
+                },
+                {
+                        x: 20.0d
+                        y: 0.0d
+                        id: "1346760BB29F4E89B18F393462AB9575"
+                        title: "D\u00e9couverte : Enderstorage"
+                        icon: {
+                                id: "enderstorage:ender_chest"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "98CBAEB08E114DECB05A7B99115AA27F"
+                                        type: "item"
+                                        item: {
+                                                id: "enderstorage:ender_chest"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "30AD5EFF1CD84A648BDA5F65A6951136"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "C556407B76954A1E8C370EF7B09A2764"
+                        ]
+                },
+                {
+                        x: 20.0d
+                        y: 2.0d
+                        id: "2DF88279FD9A47DD82BB94A3910196CB"
+                        title: "Progression : Enderstorage"
+                        icon: {
+                                id: "enderstorage:ender_pouch"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "DAC40AA636B14D31ABFB9D2BA94E08E1"
+                                        type: "item"
+                                        item: {
+                                                id: "enderstorage:ender_pouch"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "599E8C43E26E422DBBE8D84C58E7ABEA"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "1346760BB29F4E89B18F393462AB9575"
+                        ]
+                },
+                {
+                        x: 20.0d
+                        y: 4.0d
+                        id: "AF1D74D7C069422BAC35DEF74DEFF85F"
+                        title: "Ma\u00eetrise : Enderstorage"
+                        icon: {
+                                id: "enderstorage:ender_tank"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "977B697F57A94E7083F3D65E71334E4F"
+                                        type: "item"
+                                        item: {
+                                                id: "enderstorage:ender_tank"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "B035E261CEA347C19B7394429F62C2F6"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "2DF88279FD9A47DD82BB94A3910196CB"
+                        ]
+                },
+                {
+                        x: 25.0d
+                        y: 0.0d
+                        id: "6624E65DE7BD4F11BD3901A0F6DB72D0"
+                        title: "D\u00e9couverte : Ftb Quests Forge"
+                        icon: {
+                                id: "ftbquests:banner"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "9B50DAF36D114582AD7A3BD29BB61199"
+                                        type: "item"
+                                        item: {
+                                                id: "ftbquests:banner"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "8838A5A223C143D59BA8E47D6924E31C"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "AF1D74D7C069422BAC35DEF74DEFF85F"
+                        ]
+                },
+                {
+                        x: 25.0d
+                        y: 2.0d
+                        id: "D7DB523CF3A54D1190F80A17B9A92FE0"
+                        title: "Progression : Ftb Quests Forge"
+                        icon: {
+                                id: "ftbquests:barrier"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "F7DFBFCDDC7C47ED89C117A4B0E2D39B"
+                                        type: "item"
+                                        item: {
+                                                id: "ftbquests:barrier"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "030E34D8F53C4DE38AD43F69F11827BF"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "6624E65DE7BD4F11BD3901A0F6DB72D0"
+                        ]
+                },
+                {
+                        x: 25.0d
+                        y: 4.0d
+                        id: "552744136A684FA28BAF1C440044CDCC"
+                        title: "Ma\u00eetrise : Ftb Quests Forge"
+                        icon: {
+                                id: "ftbquests:book"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "C00A781F2CA04521A7CFC1872F79D127"
+                                        type: "item"
+                                        item: {
+                                                id: "ftbquests:book"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "D78DCFE7DF9D4C689C9523764425292B"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "D7DB523CF3A54D1190F80A17B9A92FE0"
+                        ]
+                },
+                {
+                        x: 0.0d
+                        y: 8.0d
+                        id: "B90494611B2346B9BC6D19E77617999A"
+                        title: "D\u00e9couverte : Questsadditions"
+                        icon: {
+                                id: "questsadditions:lootcrate_block"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "C65AC7C91D014525B78C82C2024CC9FE"
+                                        type: "item"
+                                        item: {
+                                                id: "questsadditions:lootcrate_block"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "EE598E5866F042C6950871D7BEB98F7A"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "552744136A684FA28BAF1C440044CDCC"
+                        ]
+                },
+                {
+                        x: 5.0d
+                        y: 8.0d
+                        id: "E89A1D607DFA47A5B03EAA1F8E1350EE"
+                        title: "D\u00e9couverte : Skyzeradventure"
+                        icon: {
+                                id: "changedminecraft:acacia_boat"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "EC356C929BED4E49B47CD7B794E8AAE3"
+                                        type: "item"
+                                        item: {
+                                                id: "changedminecraft:acacia_boat"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "5FCB26609408417E8A3533E3B0F92830"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "B90494611B2346B9BC6D19E77617999A"
+                        ]
+                },
+                {
+                        x: 5.0d
+                        y: 10.0d
+                        id: "D592A04F4DFA4FB0B3254E497B749C9D"
+                        title: "Progression : Skyzeradventure"
+                        icon: {
+                                id: "changedminecraft:acacia_button"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "9FF93F35CA5045A7AA404EBF26360DB0"
+                                        type: "item"
+                                        item: {
+                                                id: "changedminecraft:acacia_button"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "134093CF76E84DBCBE7045E51851559C"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "E89A1D607DFA47A5B03EAA1F8E1350EE"
+                        ]
+                },
+                {
+                        x: 5.0d
+                        y: 12.0d
+                        id: "0D89DFC61776463FA4017706E49A7C40"
+                        title: "Ma\u00eetrise : Skyzeradventure"
+                        icon: {
+                                id: "changedminecraft:acacia_door"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "9A1C8C361541432FAEAD733B79857E6E"
+                                        type: "item"
+                                        item: {
+                                                id: "changedminecraft:acacia_door"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "6B0D200EEB234FEBBFACDE2E6142BA0A"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "D592A04F4DFA4FB0B3254E497B749C9D"
+                        ]
+                },
+                {
+                        x: 10.0d
+                        y: 8.0d
+                        id: "BFDAA37EA69B45068C5FAB3CA6FD8939"
+                        title: "D\u00e9couverte : Stalwart Dungeons"
+                        icon: {
+                                id: "stalwart_dungeons:ancient_fire"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "A895C937DCAA4773B0FFA3B1AB240B79"
+                                        type: "item"
+                                        item: {
+                                                id: "stalwart_dungeons:ancient_fire"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "A066D92E5411447EB7F5AD43F627BF73"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "0D89DFC61776463FA4017706E49A7C40"
+                        ]
+                },
+                {
+                        x: 10.0d
+                        y: 10.0d
+                        id: "CADBB01E4E424C599E6175F71A0685AC"
+                        title: "Progression : Stalwart Dungeons"
+                        icon: {
+                                id: "stalwart_dungeons:awful_crystal"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "0C3CADFE8E36451E9B9185B1C166B5A5"
+                                        type: "item"
+                                        item: {
+                                                id: "stalwart_dungeons:awful_crystal"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "5717627AF54A475F9AA427709709BABE"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "BFDAA37EA69B45068C5FAB3CA6FD8939"
+                        ]
+                },
+                {
+                        x: 10.0d
+                        y: 12.0d
+                        id: "BCA5E67D62B343FBBED63027B43C1E90"
+                        title: "Ma\u00eetrise : Stalwart Dungeons"
+                        icon: {
+                                id: "stalwart_dungeons:awful_dagger"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "386CB88BB2ED4AF4BEC6C490A722AC1F"
+                                        type: "item"
+                                        item: {
+                                                id: "stalwart_dungeons:awful_dagger"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "58D26309C8A44C80A88103F834A53ED8"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "CADBB01E4E424C599E6175F71A0685AC"
+                        ]
+                }
+        ]
+}

--- a/Survie/minecraft/config/ftbquests/quests/chapters/mods_magic_gen.snbt
+++ b/Survie/minecraft/config/ftbquests/quests/chapters/mods_magic_gen.snbt
@@ -1,0 +1,462 @@
+{
+        id: "BB66998D64034D38A753265CB4B29012"
+        group: ""
+        order_index: 2
+        filename: "mods_magic_gen"
+        title: "Magie"
+        icon: {
+                id: "minecraft:enchanted_book"
+                Count: 1b
+        }
+        default_quest_shape: ""
+        default_hide_dependency_lines: false
+        quests: [
+                {
+                        x: 0.0d
+                        y: 0.0d
+                        id: "93D1FB3FC04A411AA3ACB2FA7E87AA12"
+                        title: "D\u00e9couverte : Apotheosis"
+                        icon: {
+                                id: "apotheosis:ancient_material"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "60D6C8476EB14DDC91F8C67C891ACB90"
+                                        type: "item"
+                                        item: {
+                                                id: "apotheosis:ancient_material"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "9A035CD0C0E64C309D1B6F3007A5168B"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 0.0d
+                        y: 2.0d
+                        id: "BC189B763C0641E6BC9BAC70C3AC3C97"
+                        title: "Progression : Apotheosis"
+                        icon: {
+                                id: "apotheosis:beeshelf"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "8C4B6C1862B347B8917FB6A0BD7FA80A"
+                                        type: "item"
+                                        item: {
+                                                id: "apotheosis:beeshelf"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "87FB97AF9C904570B2A653907BCCB82C"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "93D1FB3FC04A411AA3ACB2FA7E87AA12"
+                        ]
+                },
+                {
+                        x: 0.0d
+                        y: 4.0d
+                        id: "E95E44AC8105420BBF66BDDB4C7839C9"
+                        title: "Ma\u00eetrise : Apotheosis"
+                        icon: {
+                                id: "apotheosis:blazing_hellshelf"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "1F80F9F18531443CB1153C81A68C1C52"
+                                        type: "item"
+                                        item: {
+                                                id: "apotheosis:blazing_hellshelf"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "ED6A2FA7482D46F89CB653DFE604BD69"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "BC189B763C0641E6BC9BAC70C3AC3C97"
+                        ]
+                },
+                {
+                        x: 5.0d
+                        y: 0.0d
+                        id: "028E664CC4154B21BC2B10BDA0AFD29B"
+                        title: "D\u00e9couverte : Ars Nouveau"
+                        icon: {
+                                id: "ars_nouveau:ab_alternating"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "96D03764DC2A41B9888B5F09D0097217"
+                                        type: "item"
+                                        item: {
+                                                id: "ars_nouveau:ab_alternating"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "3AEA2CA750054CBB92C894F9D7697612"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "E95E44AC8105420BBF66BDDB4C7839C9"
+                        ]
+                },
+                {
+                        x: 5.0d
+                        y: 2.0d
+                        id: "2BC635F23AE946059E0A1CE56A547CE1"
+                        title: "Progression : Ars Nouveau"
+                        icon: {
+                                id: "ars_nouveau:ab_ashlar"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "18E6629F71394E3A954FF10DB6E4BD0D"
+                                        type: "item"
+                                        item: {
+                                                id: "ars_nouveau:ab_ashlar"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "DE8B38BCC21E4000B1DEED1873A1321A"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "028E664CC4154B21BC2B10BDA0AFD29B"
+                        ]
+                },
+                {
+                        x: 5.0d
+                        y: 4.0d
+                        id: "4F6CFB45E1C846BAA4929D079966EFFE"
+                        title: "Ma\u00eetrise : Ars Nouveau"
+                        icon: {
+                                id: "ars_nouveau:ab_basket"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "1B98166D638F43F29FF99FB72AAAD3CF"
+                                        type: "item"
+                                        item: {
+                                                id: "ars_nouveau:ab_basket"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "225E17402B754BDA9105E71A7CD592AE"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "2BC635F23AE946059E0A1CE56A547CE1"
+                        ]
+                },
+                {
+                        x: 10.0d
+                        y: 0.0d
+                        id: "66704563F35E40D2AA7647276FBEDA52"
+                        title: "D\u00e9couverte : Marbledsarsenal"
+                        icon: {
+                                id: "marbledsarsenal:armor_plate"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "E73B2FB1863949418B68AA5024AAA45F"
+                                        type: "item"
+                                        item: {
+                                                id: "marbledsarsenal:armor_plate"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "332619D58FBD45D88B47BCDD7953973B"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "4F6CFB45E1C846BAA4929D079966EFFE"
+                        ]
+                },
+                {
+                        x: 10.0d
+                        y: 2.0d
+                        id: "0F14FC0FDC3F410BB942F8622A6E0D83"
+                        title: "Progression : Marbledsarsenal"
+                        icon: {
+                                id: "marbledsarsenal:barbed_baseball_bat"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "0E5997AA3ECD430BBD443B4BBC4A5434"
+                                        type: "item"
+                                        item: {
+                                                id: "marbledsarsenal:barbed_baseball_bat"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "E141A7D4CD134EECB63180553CF155EB"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "66704563F35E40D2AA7647276FBEDA52"
+                        ]
+                },
+                {
+                        x: 10.0d
+                        y: 4.0d
+                        id: "B376857B9B9649D393D574CA8974A385"
+                        title: "Ma\u00eetrise : Marbledsarsenal"
+                        icon: {
+                                id: "marbledsarsenal:baseball_bat"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "0239AED8E3EB4E76AB8F5731BEBCA923"
+                                        type: "item"
+                                        item: {
+                                                id: "marbledsarsenal:baseball_bat"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "BFC28C3DB755407A8AA801E2C79990FB"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "0F14FC0FDC3F410BB942F8622A6E0D83"
+                        ]
+                },
+                {
+                        x: 15.0d
+                        y: 0.0d
+                        id: "35D809518A2147FD907C67B391F3699D"
+                        title: "D\u00e9couverte : Mysticalagradditions"
+                        icon: {
+                                id: "mysticalagradditions:awakened_draconium_crux"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "1B0FD3563D5C4BBF830CBB95C0A195EE"
+                                        type: "item"
+                                        item: {
+                                                id: "mysticalagradditions:awakened_draconium_crux"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "92660E3FDB244CDC95C718036AB3B27D"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "B376857B9B9649D393D574CA8974A385"
+                        ]
+                },
+                {
+                        x: 15.0d
+                        y: 2.0d
+                        id: "1F3CD476941F4DA2B52FBE9870EDC3A0"
+                        title: "Progression : Mysticalagradditions"
+                        icon: {
+                                id: "mysticalagradditions:creative_essence"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "8DAD16536643463B9904ADC3C37FAF35"
+                                        type: "item"
+                                        item: {
+                                                id: "mysticalagradditions:creative_essence"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "04DCE9C948A642339A684D5A5DA2ED5F"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "35D809518A2147FD907C67B391F3699D"
+                        ]
+                },
+                {
+                        x: 15.0d
+                        y: 4.0d
+                        id: "D3CECC16FA0A461BBA1614F57B92C663"
+                        title: "Ma\u00eetrise : Mysticalagradditions"
+                        icon: {
+                                id: "mysticalagradditions:dragon_egg_chunk"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "64EE57A99EFA426E88847671DF15CBC8"
+                                        type: "item"
+                                        item: {
+                                                id: "mysticalagradditions:dragon_egg_chunk"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "388C59DFEF48415B9DEEFF02AA2535A3"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "1F3CD476941F4DA2B52FBE9870EDC3A0"
+                        ]
+                },
+                {
+                        x: 20.0d
+                        y: 0.0d
+                        id: "30ED03967A104F1594519D2CF9F30BB8"
+                        title: "D\u00e9couverte : Mysticalagriculture"
+                        icon: {
+                                id: "mysticalagriculture:absorption_i_augment"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "616B5813F544401F843A2635652F2058"
+                                        type: "item"
+                                        item: {
+                                                id: "mysticalagriculture:absorption_i_augment"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "EBA14BD888F84B01999400B6E5567228"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "D3CECC16FA0A461BBA1614F57B92C663"
+                        ]
+                },
+                {
+                        x: 20.0d
+                        y: 2.0d
+                        id: "9F9C47345A984BE485902CF9A4A8FCDB"
+                        title: "Progression : Mysticalagriculture"
+                        icon: {
+                                id: "mysticalagriculture:absorption_ii_augment"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "973FCBB11B1E4A2DA8BFFB3E39A5234D"
+                                        type: "item"
+                                        item: {
+                                                id: "mysticalagriculture:absorption_ii_augment"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "110AF565AA6C4F43B68EE06A20264A87"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "30ED03967A104F1594519D2CF9F30BB8"
+                        ]
+                },
+                {
+                        x: 20.0d
+                        y: 4.0d
+                        id: "7C85B724B819439496158B22D111C0CA"
+                        title: "Ma\u00eetrise : Mysticalagriculture"
+                        icon: {
+                                id: "mysticalagriculture:absorption_iii_augment"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "FCE5702C488446BB9C8307D37132B99F"
+                                        type: "item"
+                                        item: {
+                                                id: "mysticalagriculture:absorption_iii_augment"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "1F7B41918DD24029A1C2B2CDC76A2AFC"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "9F9C47345A984BE485902CF9A4A8FCDB"
+                        ]
+                }
+        ]
+}

--- a/Survie/minecraft/config/ftbquests/quests/chapters/mods_other_gen.snbt
+++ b/Survie/minecraft/config/ftbquests/quests/chapters/mods_other_gen.snbt
@@ -1,0 +1,8292 @@
+{
+        id: "828A07F57DEC45158D8B51D0E3201E7E"
+        group: ""
+        order_index: 5
+        filename: "mods_other_gen"
+        title: "Divers"
+        icon: {
+                id: "minecraft:chest"
+                Count: 1b
+        }
+        default_quest_shape: ""
+        default_hide_dependency_lines: false
+        quests: [
+                {
+                        x: 0.0d
+                        y: 0.0d
+                        id: "330FD4D96915487E98CFC80CF4B9D73B"
+                        title: "D\u00e9couverte : Additionalcolors"
+                        icon: {
+                                id: "additionalcolors:black_acacia_fence"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "F04EF9AFCC7946FF8834A6FF5B152CF6"
+                                        type: "item"
+                                        item: {
+                                                id: "additionalcolors:black_acacia_fence"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "191E181E75144645A53AF3260FE3F506"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 0.0d
+                        y: 2.0d
+                        id: "E416314357D14F30A065920019C53196"
+                        title: "Progression : Additionalcolors"
+                        icon: {
+                                id: "additionalcolors:black_acacia_fence_gate"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "D6EFB95DB8984E9DBBF7411A1C71D1F4"
+                                        type: "item"
+                                        item: {
+                                                id: "additionalcolors:black_acacia_fence_gate"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "E16D4F18C100416A9F887416562F9319"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "330FD4D96915487E98CFC80CF4B9D73B"
+                        ]
+                },
+                {
+                        x: 0.0d
+                        y: 4.0d
+                        id: "17E99C6647AA40DBA9F979CED58EA8FB"
+                        title: "Ma\u00eetrise : Additionalcolors"
+                        icon: {
+                                id: "additionalcolors:black_acacia_planks"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "4127ABBF6B86440F87978D74862A6E8B"
+                                        type: "item"
+                                        item: {
+                                                id: "additionalcolors:black_acacia_planks"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "58D72464B2874415B10313EB7BB01A2A"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "E416314357D14F30A065920019C53196"
+                        ]
+                },
+                {
+                        x: 5.0d
+                        y: 0.0d
+                        id: "9A87280F99B64ED497DC4F87E9372F7B"
+                        title: "D\u00e9couverte : Alexsmobs"
+                        icon: {
+                                id: "alexsmobs:acacia_blossom"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "368C0CECE9C447F2BD0D1290EF395300"
+                                        type: "item"
+                                        item: {
+                                                id: "alexsmobs:acacia_blossom"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "E8E361DF014F43F1B8C11D77874A07DB"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "17E99C6647AA40DBA9F979CED58EA8FB"
+                        ]
+                },
+                {
+                        x: 5.0d
+                        y: 2.0d
+                        id: "0DB25A995C4345DDB79D45FA57020DE3"
+                        title: "Progression : Alexsmobs"
+                        icon: {
+                                id: "alexsmobs:ambergris"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "E23AC1F0946741E8A698970CBE7A5A8B"
+                                        type: "item"
+                                        item: {
+                                                id: "alexsmobs:ambergris"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "EC822C31AA1F41C485DAEA00D07AC8CC"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "9A87280F99B64ED497DC4F87E9372F7B"
+                        ]
+                },
+                {
+                        x: 5.0d
+                        y: 4.0d
+                        id: "1E2D8382FEA0408EB2C9D4C385531972"
+                        title: "Ma\u00eetrise : Alexsmobs"
+                        icon: {
+                                id: "alexsmobs:ancient_dart"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "056D8FE864DD45798DBF09363DE29959"
+                                        type: "item"
+                                        item: {
+                                                id: "alexsmobs:ancient_dart"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "6A2EE47EBB8140489E8615159B75BE6F"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "0DB25A995C4345DDB79D45FA57020DE3"
+                        ]
+                },
+                {
+                        x: 10.0d
+                        y: 0.0d
+                        id: "85AC77C8E8634F2CB75CD84620A510CD"
+                        title: "D\u00e9couverte : Allthemodium"
+                        icon: {
+                                id: "allthemodium:alloy_axe"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "25BCD44C56A24B388CBBB7E1EA94A97A"
+                                        type: "item"
+                                        item: {
+                                                id: "allthemodium:alloy_axe"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "426E687430AA485B9FE31EF235ACD6E0"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "1E2D8382FEA0408EB2C9D4C385531972"
+                        ]
+                },
+                {
+                        x: 10.0d
+                        y: 2.0d
+                        id: "D9F49778F1E34E7388B895BB657F138D"
+                        title: "Progression : Allthemodium"
+                        icon: {
+                                id: "allthemodium:alloy_pick"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "2C5D7FFFB295498AA915B40E16C58777"
+                                        type: "item"
+                                        item: {
+                                                id: "allthemodium:alloy_pick"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "5B827903047946EEA863741B0E714F8B"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "85AC77C8E8634F2CB75CD84620A510CD"
+                        ]
+                },
+                {
+                        x: 10.0d
+                        y: 4.0d
+                        id: "9B9C7B6232DD464DB36D0366FFE7549E"
+                        title: "Ma\u00eetrise : Allthemodium"
+                        icon: {
+                                id: "allthemodium:alloy_shovel"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "A1D7B9E9A95C432CA5B42432A7C858C8"
+                                        type: "item"
+                                        item: {
+                                                id: "allthemodium:alloy_shovel"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "DBCB690A44A14565BB8F61F79F1BDF51"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "D9F49778F1E34E7388B895BB657F138D"
+                        ]
+                },
+                {
+                        x: 15.0d
+                        y: 0.0d
+                        id: "C0FAF895DB714AB19047FBE8DCCA1762"
+                        title: "D\u00e9couverte : Alltheores"
+                        icon: {
+                                id: "alltheores:aluminum_block"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "F0698B2C6172436E95EDDDBAABB5D4CD"
+                                        type: "item"
+                                        item: {
+                                                id: "alltheores:aluminum_block"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "AD28D9C517A54518AA3723458BDF1A0E"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "9B9C7B6232DD464DB36D0366FFE7549E"
+                        ]
+                },
+                {
+                        x: 15.0d
+                        y: 2.0d
+                        id: "294F8E0467064861ACD86E5D22C0BB8B"
+                        title: "Progression : Alltheores"
+                        icon: {
+                                id: "alltheores:aluminum_clump"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "9794F01646164F738C479A69AB22A460"
+                                        type: "item"
+                                        item: {
+                                                id: "alltheores:aluminum_clump"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "545F43E48DF641D1B24457F43E562854"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "C0FAF895DB714AB19047FBE8DCCA1762"
+                        ]
+                },
+                {
+                        x: 15.0d
+                        y: 4.0d
+                        id: "BCDD128B16A149DC8599FBFFC007F902"
+                        title: "Ma\u00eetrise : Alltheores"
+                        icon: {
+                                id: "alltheores:aluminum_crystal"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "6F5DCDC516D54028839E87B9029EC587"
+                                        type: "item"
+                                        item: {
+                                                id: "alltheores:aluminum_crystal"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "9797446C276E4A7ABDE5EB884B99D39B"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "294F8E0467064861ACD86E5D22C0BB8B"
+                        ]
+                },
+                {
+                        x: 20.0d
+                        y: 0.0d
+                        id: "DA285231EE5F4A719C8D38D7B1D37A27"
+                        title: "D\u00e9couverte : Amperecraft 0.3 Forge 1.18"
+                        icon: {
+                                id: "ampere_craft:battery"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "B9CC331C644847ACACA2F43FC9C2EA6C"
+                                        type: "item"
+                                        item: {
+                                                id: "ampere_craft:battery"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "5D0B870361DB4CCD91B5969EF6CC6580"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "BCDD128B16A149DC8599FBFFC007F902"
+                        ]
+                },
+                {
+                        x: 20.0d
+                        y: 2.0d
+                        id: "9B54C44A7127474FA857245697393A6C"
+                        title: "Progression : Amperecraft 0.3 Forge 1.18"
+                        icon: {
+                                id: "ampere_craft:batterycell"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "5FEB29B07B244A74A00DC0EEA8FB282B"
+                                        type: "item"
+                                        item: {
+                                                id: "ampere_craft:batterycell"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "DCA1FF5311A245EBBE8902F76AA3DFD5"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "DA285231EE5F4A719C8D38D7B1D37A27"
+                        ]
+                },
+                {
+                        x: 20.0d
+                        y: 4.0d
+                        id: "3B32BEF932AD4EBA8B1628AC5A2BB692"
+                        title: "Ma\u00eetrise : Amperecraft 0.3 Forge 1.18"
+                        icon: {
+                                id: "ampere_craft:batterycelldeluxe"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "96EE2718558048E0AC51D260CC2B4D67"
+                                        type: "item"
+                                        item: {
+                                                id: "ampere_craft:batterycelldeluxe"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "F4CA032B12E146A7B67D6C2E7E75E732"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "9B54C44A7127474FA857245697393A6C"
+                        ]
+                },
+                {
+                        x: 25.0d
+                        y: 0.0d
+                        id: "329189874BBF4E34BC6800009F7A70FB"
+                        title: "D\u00e9couverte : Aquamirae"
+                        icon: {
+                                id: "aquamirae:abyssal_amethyst"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "9A2653A8DC3741F0A7BD89F134E6F856"
+                                        type: "item"
+                                        item: {
+                                                id: "aquamirae:abyssal_amethyst"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "623801E141914EEBB29242E4DEEFB7A7"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "3B32BEF932AD4EBA8B1628AC5A2BB692"
+                        ]
+                },
+                {
+                        x: 25.0d
+                        y: 2.0d
+                        id: "C7338963221B44CEBB8F19CDF1F92B9B"
+                        title: "Progression : Aquamirae"
+                        icon: {
+                                id: "aquamirae:abyssal_boots"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "64F9EAD0B5AC4778BBA8B127D6F98526"
+                                        type: "item"
+                                        item: {
+                                                id: "aquamirae:abyssal_boots"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "E864AA14DCBC44809A8AD95B3CD1D54F"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "329189874BBF4E34BC6800009F7A70FB"
+                        ]
+                },
+                {
+                        x: 25.0d
+                        y: 4.0d
+                        id: "FF3540238EDE4FAD907EDBFB53797A17"
+                        title: "Ma\u00eetrise : Aquamirae"
+                        icon: {
+                                id: "aquamirae:abyssal_brigantine"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "55C933ADD18B4D46830DF8B723B3B5B9"
+                                        type: "item"
+                                        item: {
+                                                id: "aquamirae:abyssal_brigantine"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "063BF62D76EC4670B8D42F8ECA3821C8"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "C7338963221B44CEBB8F19CDF1F92B9B"
+                        ]
+                },
+                {
+                        x: 0.0d
+                        y: 8.0d
+                        id: "D6D147A7F3F944E7A3D27839C682A971"
+                        title: "D\u00e9couverte : Betteranimalsplus"
+                        icon: {
+                                id: "betteranimalsplus:advancement_icon_badger"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "82B5B92569604A208D409C52B9C7D704"
+                                        type: "item"
+                                        item: {
+                                                id: "betteranimalsplus:advancement_icon_badger"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "C0EBDB7B5FBC47419A642B4ADA087B99"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "FF3540238EDE4FAD907EDBFB53797A17"
+                        ]
+                },
+                {
+                        x: 0.0d
+                        y: 10.0d
+                        id: "B86B6F6F5306457FB6E2186B5E91B6DA"
+                        title: "Progression : Betteranimalsplus"
+                        icon: {
+                                id: "betteranimalsplus:advancement_icon_jellyfish"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "422B8D2BEA634C0DA0AD3C9C3B2BC271"
+                                        type: "item"
+                                        item: {
+                                                id: "betteranimalsplus:advancement_icon_jellyfish"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "7E8D18BC7B2C44499850FC3C6AD4C815"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "D6D147A7F3F944E7A3D27839C682A971"
+                        ]
+                },
+                {
+                        x: 0.0d
+                        y: 12.0d
+                        id: "5AA5C7F329CD4FA98E48ADC92948F130"
+                        title: "Ma\u00eetrise : Betteranimalsplus"
+                        icon: {
+                                id: "betteranimalsplus:advancement_icon_jellyfish_cross"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "E07F505B4CC8404D812EC22E157ABD76"
+                                        type: "item"
+                                        item: {
+                                                id: "betteranimalsplus:advancement_icon_jellyfish_cross"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "E43DB4909CB94E09BCAC664EB92379EA"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "B86B6F6F5306457FB6E2186B5E91B6DA"
+                        ]
+                },
+                {
+                        x: 5.0d
+                        y: 8.0d
+                        id: "047C037DCCB44363BEB1893CD6CB04EE"
+                        title: "D\u00e9couverte : Block Swapper"
+                        icon: {
+                                id: "blockswapper:copper_block_swapper"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "8014C3A50AEA4EEBB578F21D4B79B7E3"
+                                        type: "item"
+                                        item: {
+                                                id: "blockswapper:copper_block_swapper"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "9208455F228440C783FAE5602FB13BDF"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "5AA5C7F329CD4FA98E48ADC92948F130"
+                        ]
+                },
+                {
+                        x: 5.0d
+                        y: 10.0d
+                        id: "0CBEDF16D03947D3923A1E3E3D2B0229"
+                        title: "Progression : Block Swapper"
+                        icon: {
+                                id: "blockswapper:diamond_block_swapper"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "7F07C5B80CEB4526AEFCB04489959795"
+                                        type: "item"
+                                        item: {
+                                                id: "blockswapper:diamond_block_swapper"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "3795F764B6564DCEBD780E96A8C519EC"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "047C037DCCB44363BEB1893CD6CB04EE"
+                        ]
+                },
+                {
+                        x: 10.0d
+                        y: 8.0d
+                        id: "0714D2870BFA44C6B214F28688C82ADF"
+                        title: "D\u00e9couverte : Blocksyouneed Luna"
+                        icon: {
+                                id: "blocksyouneed_luna:acacia_brace"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "94136E6412DB4D8788EB9E09B3B32683"
+                                        type: "item"
+                                        item: {
+                                                id: "blocksyouneed_luna:acacia_brace"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "EEBCC08308324FA1938A22C9B3624518"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "0CBEDF16D03947D3923A1E3E3D2B0229"
+                        ]
+                },
+                {
+                        x: 10.0d
+                        y: 10.0d
+                        id: "51FFC5C174B54B21AEF565E1DF74F96E"
+                        title: "Progression : Blocksyouneed Luna"
+                        icon: {
+                                id: "blocksyouneed_luna:acacia_carved_log"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "588E6547C1874095A301D0BE3AEB8C4F"
+                                        type: "item"
+                                        item: {
+                                                id: "blocksyouneed_luna:acacia_carved_log"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "815D351E31684941A2819149CF1DF1F1"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "0714D2870BFA44C6B214F28688C82ADF"
+                        ]
+                },
+                {
+                        x: 10.0d
+                        y: 12.0d
+                        id: "EBB22E404CCC40CEBFE06F51B94B60E3"
+                        title: "Ma\u00eetrise : Blocksyouneed Luna"
+                        icon: {
+                                id: "blocksyouneed_luna:acacia_dock_tie"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "C893AACCDA6746DDACDDED142F914D9A"
+                                        type: "item"
+                                        item: {
+                                                id: "blocksyouneed_luna:acacia_dock_tie"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "3E98831C5FF14DC6A9E2234ED4F116C7"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "51FFC5C174B54B21AEF565E1DF74F96E"
+                        ]
+                },
+                {
+                        x: 15.0d
+                        y: 8.0d
+                        id: "60995C483F564AD1BC17A7240129A17B"
+                        title: "D\u00e9couverte : Born In Chaos [Forge]1.18.2"
+                        icon: {
+                                id: "born_in_chaos_v1:ai"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "92485F007AF043229E194DBD4F6A43C5"
+                                        type: "item"
+                                        item: {
+                                                id: "born_in_chaos_v1:ai"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "180C55B3B5DD4E31B6A4C01F01A60556"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "EBB22E404CCC40CEBFE06F51B94B60E3"
+                        ]
+                },
+                {
+                        x: 15.0d
+                        y: 10.0d
+                        id: "4C0CC613132C4096B9DCE30678F5987B"
+                        title: "Progression : Born In Chaos [Forge]1.18.2"
+                        icon: {
+                                id: "born_in_chaos_v1:anluka_doors"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "56DD5FA6BF414137A12093D949952F4A"
+                                        type: "item"
+                                        item: {
+                                                id: "born_in_chaos_v1:anluka_doors"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "9961F82D0980449E9F10FE3818A04A54"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "60995C483F564AD1BC17A7240129A17B"
+                        ]
+                },
+                {
+                        x: 15.0d
+                        y: 12.0d
+                        id: "7F741CC21A4742BEB529EC9891DF5B32"
+                        title: "Ma\u00eetrise : Born In Chaos [Forge]1.18.2"
+                        icon: {
+                                id: "born_in_chaos_v1:argillite_lamp"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "8F65CFBB9B864A4DAE727ACFA9EF6198"
+                                        type: "item"
+                                        item: {
+                                                id: "born_in_chaos_v1:argillite_lamp"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "97249B99AF2D4105BF734E4ED4FE9F23"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "4C0CC613132C4096B9DCE30678F5987B"
+                        ]
+                },
+                {
+                        x: 20.0d
+                        y: 8.0d
+                        id: "8435AAC7E0184B0885B17F023C693215"
+                        title: "D\u00e9couverte : Buildersaddition"
+                        icon: {
+                                id: "buildersaddition:acacia_vertical_slab"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "442667682D254124B3382ED7D62EC4A0"
+                                        type: "item"
+                                        item: {
+                                                id: "buildersaddition:acacia_vertical_slab"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "48CDFA08F57D40B2A528D2D49359E8C0"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "7F741CC21A4742BEB529EC9891DF5B32"
+                        ]
+                },
+                {
+                        x: 20.0d
+                        y: 10.0d
+                        id: "3E7E07764681433FAD6C6B5EC6737753"
+                        title: "Progression : Buildersaddition"
+                        icon: {
+                                id: "buildersaddition:andesite_vertical_slab"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "5AA9223A1940417E845A0356AABB8A26"
+                                        type: "item"
+                                        item: {
+                                                id: "buildersaddition:andesite_vertical_slab"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "01AD80DA5A1446BDB61F3083005E5DCC"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "8435AAC7E0184B0885B17F023C693215"
+                        ]
+                },
+                {
+                        x: 20.0d
+                        y: 12.0d
+                        id: "FD0AA47BF586468FBE2ABD0885998D95"
+                        title: "Ma\u00eetrise : Buildersaddition"
+                        icon: {
+                                id: "buildersaddition:arcade"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "16FD76595E214A239FFCE28721384767"
+                                        type: "item"
+                                        item: {
+                                                id: "buildersaddition:arcade"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "1C484E6D3BB042E1BC8174150461E868"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "3E7E07764681433FAD6C6B5EC6737753"
+                        ]
+                },
+                {
+                        x: 25.0d
+                        y: 8.0d
+                        id: "EC7E7CB3FA194823AED376B20DE7349E"
+                        title: "D\u00e9couverte : Buildersdelight"
+                        icon: {
+                                id: "buildersdelight:acacia_chair_1"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "2937532D44864AE794F52B420C1AFC04"
+                                        type: "item"
+                                        item: {
+                                                id: "buildersdelight:acacia_chair_1"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "BAC0BDDC9263409596D5063CDB03E3D8"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "FD0AA47BF586468FBE2ABD0885998D95"
+                        ]
+                },
+                {
+                        x: 25.0d
+                        y: 10.0d
+                        id: "435107579D97429E96111065C81989DF"
+                        title: "Progression : Buildersdelight"
+                        icon: {
+                                id: "buildersdelight:acacia_chair_2"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "F48285082CE2426C97DBFD2077248BCC"
+                                        type: "item"
+                                        item: {
+                                                id: "buildersdelight:acacia_chair_2"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "61DA6E01722347228B56509A1071B930"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "EC7E7CB3FA194823AED376B20DE7349E"
+                        ]
+                },
+                {
+                        x: 25.0d
+                        y: 12.0d
+                        id: "76BEE688EA3E4DA7A3DD4580E12FEDA2"
+                        title: "Ma\u00eetrise : Buildersdelight"
+                        icon: {
+                                id: "buildersdelight:acacia_frame_1"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "9974FB635D864140B929C984BDC9D354"
+                                        type: "item"
+                                        item: {
+                                                id: "buildersdelight:acacia_frame_1"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "9D39FFB9A4B94A58957269B62BF86F24"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "435107579D97429E96111065C81989DF"
+                        ]
+                },
+                {
+                        x: 0.0d
+                        y: 16.0d
+                        id: "ABFD8F1C67D84B9AA746393B947D2B98"
+                        title: "D\u00e9couverte : Buildinggadgets"
+                        icon: {
+                                id: "buildinggadgets:construction_block"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "D167E260954A4A358BC0E9D94503D331"
+                                        type: "item"
+                                        item: {
+                                                id: "buildinggadgets:construction_block"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "538B13DFFEB7488CAD319BBB67F2783C"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "76BEE688EA3E4DA7A3DD4580E12FEDA2"
+                        ]
+                },
+                {
+                        x: 0.0d
+                        y: 18.0d
+                        id: "B57F8F0C34E94DA48EEE6EE34BA9D72B"
+                        title: "Progression : Buildinggadgets"
+                        icon: {
+                                id: "buildinggadgets:construction_block_dense"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "23C0CD99BAD54AD4BB5B8EF7027EF13D"
+                                        type: "item"
+                                        item: {
+                                                id: "buildinggadgets:construction_block_dense"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "FC7C6084EA9148628626982C43342BCC"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "ABFD8F1C67D84B9AA746393B947D2B98"
+                        ]
+                },
+                {
+                        x: 0.0d
+                        y: 20.0d
+                        id: "07B2C2196E414AF1A583DBE295FAE5C0"
+                        title: "Ma\u00eetrise : Buildinggadgets"
+                        icon: {
+                                id: "buildinggadgets:construction_block_powder"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "4EB960DA940F4EFCBECDE25273BCDC56"
+                                        type: "item"
+                                        item: {
+                                                id: "buildinggadgets:construction_block_powder"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "5725444CF8E04A5E9ACC25356E43B6D0"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "B57F8F0C34E94DA48EEE6EE34BA9D72B"
+                        ]
+                },
+                {
+                        x: 5.0d
+                        y: 16.0d
+                        id: "D84F7C9FEB5A4DF79AFBB2E5CA154F35"
+                        title: "D\u00e9couverte : Buildpastemod"
+                        icon: {
+                                id: "buildpaste:position_selector"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "0B91A549C3B94A389A481C7010A15F5C"
+                                        type: "item"
+                                        item: {
+                                                id: "buildpaste:position_selector"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "1FECC32999E943DE9C0DC65576775CA6"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "07B2C2196E414AF1A583DBE295FAE5C0"
+                        ]
+                },
+                {
+                        x: 5.0d
+                        y: 18.0d
+                        id: "30DACAA67EB04B548CF2B38837AE2C0C"
+                        title: "Progression : Buildpastemod"
+                        icon: {
+                                id: "buildpaste:structure_builder"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "8AB507A4A5344AEAB4F2D9329B220497"
+                                        type: "item"
+                                        item: {
+                                                id: "buildpaste:structure_builder"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "2142ED361A794920BB8A7D8C77789FF9"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "D84F7C9FEB5A4DF79AFBB2E5CA154F35"
+                        ]
+                },
+                {
+                        x: 10.0d
+                        y: 16.0d
+                        id: "2CD909D128F54790BD797A07FFCD4E1A"
+                        title: "D\u00e9couverte : Camera"
+                        icon: {
+                                id: "camera:album"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "3B73F920214446269C0F29B6D0794E9F"
+                                        type: "item"
+                                        item: {
+                                                id: "camera:album"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "E4F6B06CA9704CA081B44B8F6BF07F70"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "30DACAA67EB04B548CF2B38837AE2C0C"
+                        ]
+                },
+                {
+                        x: 10.0d
+                        y: 18.0d
+                        id: "416514F354F64694B4D08103A137B2B3"
+                        title: "Progression : Camera"
+                        icon: {
+                                id: "camera:camera"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "3EFF75B7FDEB4A3AA3E2834ED379FB7D"
+                                        type: "item"
+                                        item: {
+                                                id: "camera:camera"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "32A6470F1AC14633890FE3DAEB9B13A7"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "2CD909D128F54790BD797A07FFCD4E1A"
+                        ]
+                },
+                {
+                        x: 10.0d
+                        y: 20.0d
+                        id: "6D05309F6FF54EA6A72BA10011D59CBF"
+                        title: "Ma\u00eetrise : Camera"
+                        icon: {
+                                id: "camera:image"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "E1EFFF761D90482E86BEDB7E86D2D214"
+                                        type: "item"
+                                        item: {
+                                                id: "camera:image"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "9AB4AA5AC14E4108952F6777D2CFE324"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "416514F354F64694B4D08103A137B2B3"
+                        ]
+                },
+                {
+                        x: 15.0d
+                        y: 16.0d
+                        id: "CD975ADD5DAB4C6C9C83289197CFE340"
+                        title: "D\u00e9couverte : Car"
+                        icon: {
+                                id: "car:acacia_body"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "4AEA5451C28B45F3B3D065C2B6F80844"
+                                        type: "item"
+                                        item: {
+                                                id: "car:acacia_body"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "B5B746E4AF6B489E90A8185868264060"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "6D05309F6FF54EA6A72BA10011D59CBF"
+                        ]
+                },
+                {
+                        x: 15.0d
+                        y: 18.0d
+                        id: "2B794E4ECA7F4492897A81A631BE8333"
+                        title: "Progression : Car"
+                        icon: {
+                                id: "car:acacia_bumper"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "C822212A17DD4AE9B93B6A7B8CDBFC77"
+                                        type: "item"
+                                        item: {
+                                                id: "car:acacia_bumper"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "EAB87F146B8C43AD9B4A41D5CAEF09B0"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "CD975ADD5DAB4C6C9C83289197CFE340"
+                        ]
+                },
+                {
+                        x: 15.0d
+                        y: 20.0d
+                        id: "99C16302DDFF463F8EDA0AD3510C0964"
+                        title: "Ma\u00eetrise : Car"
+                        icon: {
+                                id: "car:acacia_license_plate_holder"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "A7F747514A514FEE8933500D8EEA113C"
+                                        type: "item"
+                                        item: {
+                                                id: "car:acacia_license_plate_holder"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "665D359D78924A55808914FAB31BBB2E"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "2B794E4ECA7F4492897A81A631BE8333"
+                        ]
+                },
+                {
+                        x: 20.0d
+                        y: 16.0d
+                        id: "FC7358B1D8C14F879A22B387C2A23C35"
+                        title: "D\u00e9couverte : Cfm"
+                        icon: {
+                                id: "cfm:acacia_bedside_cabinet"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "AC34D9CD11204679A37126DD5957DC72"
+                                        type: "item"
+                                        item: {
+                                                id: "cfm:acacia_bedside_cabinet"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "363DB9422257419881DC5482EA2158AC"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "99C16302DDFF463F8EDA0AD3510C0964"
+                        ]
+                },
+                {
+                        x: 20.0d
+                        y: 18.0d
+                        id: "31AA99F7880945618C6A5D8D08F2BFB6"
+                        title: "Progression : Cfm"
+                        icon: {
+                                id: "cfm:acacia_blinds"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "368F2EEB0746403FB5CD302B15354119"
+                                        type: "item"
+                                        item: {
+                                                id: "cfm:acacia_blinds"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "6AF8566E98ED460FA39D7E59D18EF54D"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "FC7358B1D8C14F879A22B387C2A23C35"
+                        ]
+                },
+                {
+                        x: 20.0d
+                        y: 20.0d
+                        id: "69155233DE8D4CC4B909F995369666F5"
+                        title: "Ma\u00eetrise : Cfm"
+                        icon: {
+                                id: "cfm:acacia_cabinet"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "C2A11B72FEEA4CEE9453B5B4A7CBC51D"
+                                        type: "item"
+                                        item: {
+                                                id: "cfm:acacia_cabinet"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "BE19A4AED0ED4B6DA4747C00C3A54BF4"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "31AA99F7880945618C6A5D8D08F2BFB6"
+                        ]
+                },
+                {
+                        x: 25.0d
+                        y: 16.0d
+                        id: "CD7DD47A09194C6CAB8E741995E1132D"
+                        title: "D\u00e9couverte : Chipped Forge"
+                        icon: {
+                                id: "chipped:acacia_door_1"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "881D6BF542CB4FD7B186A83A6A702972"
+                                        type: "item"
+                                        item: {
+                                                id: "chipped:acacia_door_1"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "16215C1493F34B70B93BD26722A51498"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "69155233DE8D4CC4B909F995369666F5"
+                        ]
+                },
+                {
+                        x: 25.0d
+                        y: 18.0d
+                        id: "5480CA97419749F6AAF3DBE34FAA39CA"
+                        title: "Progression : Chipped Forge"
+                        icon: {
+                                id: "chipped:acacia_door_10"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "0E68EC89AB564B3486484B3E1DD65006"
+                                        type: "item"
+                                        item: {
+                                                id: "chipped:acacia_door_10"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "88C2DB87B53043ECA9D08BF2FB0C448A"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "CD7DD47A09194C6CAB8E741995E1132D"
+                        ]
+                },
+                {
+                        x: 25.0d
+                        y: 20.0d
+                        id: "D858383AE4344A0EA2B76363CCBB769B"
+                        title: "Ma\u00eetrise : Chipped Forge"
+                        icon: {
+                                id: "chipped:acacia_door_11"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "C99763B2D76540D88794974773B1CAE6"
+                                        type: "item"
+                                        item: {
+                                                id: "chipped:acacia_door_11"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "45ED13AF582B4168B7C0821B710923EE"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "5480CA97419749F6AAF3DBE34FAA39CA"
+                        ]
+                },
+                {
+                        x: 0.0d
+                        y: 24.0d
+                        id: "63E24D26407749249ECB9F4967616D8A"
+                        title: "D\u00e9couverte : Citadel"
+                        icon: {
+                                id: "citadel:citadel_book"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "6B774AF44793434C994777B2DC903801"
+                                        type: "item"
+                                        item: {
+                                                id: "citadel:citadel_book"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "F9C2299936894747B1EE50EC70E204BB"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "D858383AE4344A0EA2B76363CCBB769B"
+                        ]
+                },
+                {
+                        x: 0.0d
+                        y: 26.0d
+                        id: "BF9DB1FD2B3C42549C340AE6EBCC8AF2"
+                        title: "Progression : Citadel"
+                        icon: {
+                                id: "citadel:debug"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "E39D20B7A12E425F912C3830A7CBC2B1"
+                                        type: "item"
+                                        item: {
+                                                id: "citadel:debug"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "160E7A1809AA4A0DA56EF6A59955321D"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "63E24D26407749249ECB9F4967616D8A"
+                        ]
+                },
+                {
+                        x: 0.0d
+                        y: 28.0d
+                        id: "5652DD1A873C4AF88DC9EC1B2EEE7E63"
+                        title: "Ma\u00eetrise : Citadel"
+                        icon: {
+                                id: "citadel:effect_item"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "5801082CA7F643E48255F8075EE30354"
+                                        type: "item"
+                                        item: {
+                                                id: "citadel:effect_item"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "B81E33B9A0FE466DAEFA44AAA58D6302"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "BF9DB1FD2B3C42549C340AE6EBCC8AF2"
+                        ]
+                },
+                {
+                        x: 5.0d
+                        y: 24.0d
+                        id: "E31439DF1D7B4ADEB8C0DF9F779931A4"
+                        title: "D\u00e9couverte : Citymod Release"
+                        icon: {
+                                id: "citymod:air_conditioning"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "356565255638478A95ED06FB423E3EA5"
+                                        type: "item"
+                                        item: {
+                                                id: "citymod:air_conditioning"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "818F8BDD18F04B418A8B62FAC1F1F41A"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "5652DD1A873C4AF88DC9EC1B2EEE7E63"
+                        ]
+                },
+                {
+                        x: 5.0d
+                        y: 26.0d
+                        id: "2DDAE0A743184BC5AD008B8C009DE92D"
+                        title: "Progression : Citymod Release"
+                        icon: {
+                                id: "citymod:air_conditioning_external_unit"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "1B0CCF06865B48F9BE845329452B686A"
+                                        type: "item"
+                                        item: {
+                                                id: "citymod:air_conditioning_external_unit"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "7EEBEB9066CE4EAF9050346B86C0058C"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "E31439DF1D7B4ADEB8C0DF9F779931A4"
+                        ]
+                },
+                {
+                        x: 5.0d
+                        y: 28.0d
+                        id: "F5343263F16448D0B8F71D0EBCABF3D5"
+                        title: "Ma\u00eetrise : Citymod Release"
+                        icon: {
+                                id: "citymod:barrier_gate_down"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "A5895ED4D897438DA45D4870404A13DC"
+                                        type: "item"
+                                        item: {
+                                                id: "citymod:barrier_gate_down"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "4F673E77D6864193A4A232E473A3F297"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "2DDAE0A743184BC5AD008B8C009DE92D"
+                        ]
+                },
+                {
+                        x: 10.0d
+                        y: 24.0d
+                        id: "8ACAED67A4A94BBF925466C3A7F625ED"
+                        title: "D\u00e9couverte : Coloredbricks"
+                        icon: {
+                                id: "coloredbricks:black_brick"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "1F28A02CB0DF4D419F37008F6C332CBB"
+                                        type: "item"
+                                        item: {
+                                                id: "coloredbricks:black_brick"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "0565832B86A747ACA5EB3BC9785A8BCC"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "F5343263F16448D0B8F71D0EBCABF3D5"
+                        ]
+                },
+                {
+                        x: 10.0d
+                        y: 26.0d
+                        id: "39F38C95779B4C07820AE7644F7B79D7"
+                        title: "Progression : Coloredbricks"
+                        icon: {
+                                id: "coloredbricks:black_brick_slab"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "1DE9FBD544A54B40896C7DD3E2B3BF16"
+                                        type: "item"
+                                        item: {
+                                                id: "coloredbricks:black_brick_slab"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "CAB8417B83C14D6DB6663EE64A3B9943"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "8ACAED67A4A94BBF925466C3A7F625ED"
+                        ]
+                },
+                {
+                        x: 10.0d
+                        y: 28.0d
+                        id: "AAC5CFAC4A3F4CAF994A3CCDE40CF81E"
+                        title: "Ma\u00eetrise : Coloredbricks"
+                        icon: {
+                                id: "coloredbricks:black_brick_stairs"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "505F9B761BFF45E391CCE83F602B2A2C"
+                                        type: "item"
+                                        item: {
+                                                id: "coloredbricks:black_brick_stairs"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "DDE01EC39C014AC59D47FC9EF4A9DFC4"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "39F38C95779B4C07820AE7644F7B79D7"
+                        ]
+                },
+                {
+                        x: 15.0d
+                        y: 24.0d
+                        id: "09FFD03DD9644C69A8443E3289433808"
+                        title: "D\u00e9couverte : Compactvoidminers R1.18.2"
+                        icon: {
+                                id: "compactvoidminers:blank_filter"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "00DCDA88E753412E9AE21B36015DAB2C"
+                                        type: "item"
+                                        item: {
+                                                id: "compactvoidminers:blank_filter"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "FA30C908F60F417CADA8C2B8156F0C59"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "AAC5CFAC4A3F4CAF994A3CCDE40CF81E"
+                        ]
+                },
+                {
+                        x: 15.0d
+                        y: 26.0d
+                        id: "738C874FEF8145FF88CD73AFFFE1F71A"
+                        title: "Progression : Compactvoidminers R1.18.2"
+                        icon: {
+                                id: "compactvoidminers:tag_filter"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "3E7C2214AE4140D7A858FBD1621D3A6B"
+                                        type: "item"
+                                        item: {
+                                                id: "compactvoidminers:tag_filter"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "E2A66AAAC35B472EB91947632E74F27E"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "09FFD03DD9644C69A8443E3289433808"
+                        ]
+                },
+                {
+                        x: 15.0d
+                        y: 28.0d
+                        id: "9AB3CD9907DD49B2A31D234B2A65952C"
+                        title: "Ma\u00eetrise : Compactvoidminers R1.18.2"
+                        icon: {
+                                id: "compactvoidminers:tag_filter_crop"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "2B3C8651683748DBB2710AAB012ACE12"
+                                        type: "item"
+                                        item: {
+                                                id: "compactvoidminers:tag_filter_crop"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "76C1309B9FDB4A04940E8AA50A675B93"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "738C874FEF8145FF88CD73AFFFE1F71A"
+                        ]
+                },
+                {
+                        x: 20.0d
+                        y: 24.0d
+                        id: "DB89AB5D6E16438B9CE08FEEB6297EB4"
+                        title: "D\u00e9couverte : Constructionwand"
+                        icon: {
+                                id: "constructionwand:core_angel"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "179FDB91A2FF40E3BF888BE8F29AA917"
+                                        type: "item"
+                                        item: {
+                                                id: "constructionwand:core_angel"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "1AE8390241E241578A1F4E336D5E5375"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "9AB3CD9907DD49B2A31D234B2A65952C"
+                        ]
+                },
+                {
+                        x: 20.0d
+                        y: 26.0d
+                        id: "4817CA7B93864D22AE350E50C84875B9"
+                        title: "Progression : Constructionwand"
+                        icon: {
+                                id: "constructionwand:core_destruction"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "17838C47D0A143C2BAECE69AA03F32D2"
+                                        type: "item"
+                                        item: {
+                                                id: "constructionwand:core_destruction"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "F73A35E47D464418B0F06AB93290E819"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "DB89AB5D6E16438B9CE08FEEB6297EB4"
+                        ]
+                },
+                {
+                        x: 20.0d
+                        y: 28.0d
+                        id: "4B28952F3D454D02B185668E8676DFB0"
+                        title: "Ma\u00eetrise : Constructionwand"
+                        icon: {
+                                id: "constructionwand:diamond_wand"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "3F7F2A5466914810B7261E3DCD1BD115"
+                                        type: "item"
+                                        item: {
+                                                id: "constructionwand:diamond_wand"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "4FAEE2873635415698C0085E577C828D"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "4817CA7B93864D22AE350E50C84875B9"
+                        ]
+                },
+                {
+                        x: 25.0d
+                        y: 24.0d
+                        id: "012BACD03FE54EC69AFA74A6C0126AD9"
+                        title: "D\u00e9couverte : Cookingforblockheads Forge"
+                        icon: {
+                                id: "cookingforblockheads:black_kitchen_floor"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "1FFBAA737A7D41499C1816756FC70701"
+                                        type: "item"
+                                        item: {
+                                                id: "cookingforblockheads:black_kitchen_floor"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "614D16DB28EF4FEF8B5A9F19FA5AA71C"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "4B28952F3D454D02B185668E8676DFB0"
+                        ]
+                },
+                {
+                        x: 25.0d
+                        y: 26.0d
+                        id: "442113C3E25D4679BD317385B98AE175"
+                        title: "Progression : Cookingforblockheads Forge"
+                        icon: {
+                                id: "cookingforblockheads:blue_kitchen_floor"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "47EA4CA7B2B54C7C9B33BDEFF25ECAED"
+                                        type: "item"
+                                        item: {
+                                                id: "cookingforblockheads:blue_kitchen_floor"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "9C73E4FF3DE44EC39CA03C97EA4CD556"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "012BACD03FE54EC69AFA74A6C0126AD9"
+                        ]
+                },
+                {
+                        x: 25.0d
+                        y: 28.0d
+                        id: "46444EB0D4864472B2D921ED5BF5BA68"
+                        title: "Ma\u00eetrise : Cookingforblockheads Forge"
+                        icon: {
+                                id: "cookingforblockheads:brown_kitchen_floor"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "6CBCF4ABE357454DA2147837E45F9F2A"
+                                        type: "item"
+                                        item: {
+                                                id: "cookingforblockheads:brown_kitchen_floor"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "5B579A0EAEE84E36B29E9C291DEB72E4"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "442113C3E25D4679BD317385B98AE175"
+                        ]
+                },
+                {
+                        x: 0.0d
+                        y: 32.0d
+                        id: "51FB2102A88A44ACA0ECE1D4831E0B21"
+                        title: "D\u00e9couverte : Create"
+                        icon: {
+                                id: "create:acacia_window"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "8E2479E6E2274DD59C96581EA96A428F"
+                                        type: "item"
+                                        item: {
+                                                id: "create:acacia_window"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "63783F23B6E3436DA1ABCFBC3F1183AA"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "46444EB0D4864472B2D921ED5BF5BA68"
+                        ]
+                },
+                {
+                        x: 0.0d
+                        y: 34.0d
+                        id: "A4029D9FCA694B8D8CC6DDC8906E2AFD"
+                        title: "Progression : Create"
+                        icon: {
+                                id: "create:acacia_window_pane"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "87E1E9900D594443A7EC480C76B83871"
+                                        type: "item"
+                                        item: {
+                                                id: "create:acacia_window_pane"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "2FCF926119304445BCFF192EF1C3500F"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "51FB2102A88A44ACA0ECE1D4831E0B21"
+                        ]
+                },
+                {
+                        x: 0.0d
+                        y: 36.0d
+                        id: "9E40DC9687B346E39310DB123E1EA94C"
+                        title: "Ma\u00eetrise : Create"
+                        icon: {
+                                id: "create:accelerator"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "07A7538818EC44408BAECE82306F08F8"
+                                        type: "item"
+                                        item: {
+                                                id: "create:accelerator"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "8D5D54E5E1BA44A18C3199F4F4652FD0"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "A4029D9FCA694B8D8CC6DDC8906E2AFD"
+                        ]
+                },
+                {
+                        x: 5.0d
+                        y: 32.0d
+                        id: "EECCE77227014CC782D04F5DB8134112"
+                        title: "D\u00e9couverte : Create Central Kitchen"
+                        icon: {
+                                id: "create_central_kitchen:aloe_cake_slice"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "562D9CED1732467BAB71408FBEDBFF70"
+                                        type: "item"
+                                        item: {
+                                                id: "create_central_kitchen:aloe_cake_slice"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "667EBE486EA84B6DAF99CE7BD9D9AC11"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "9E40DC9687B346E39310DB123E1EA94C"
+                        ]
+                },
+                {
+                        x: 5.0d
+                        y: 34.0d
+                        id: "12D6E8D1072144A6898BAF8C6CBD4395"
+                        title: "Progression : Create Central Kitchen"
+                        icon: {
+                                id: "create_central_kitchen:aloe_gel_bucket"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "CE17633E17D44ECD995D9E7565C3288B"
+                                        type: "item"
+                                        item: {
+                                                id: "create_central_kitchen:aloe_gel_bucket"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "F5D3401B907D42ACB4E3085E8E58BA21"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "EECCE77227014CC782D04F5DB8134112"
+                        ]
+                },
+                {
+                        x: 5.0d
+                        y: 36.0d
+                        id: "65C860B48A5945AB8947E26381CAA679"
+                        title: "Ma\u00eetrise : Create Central Kitchen"
+                        icon: {
+                                id: "create_central_kitchen:brewing_guide"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "CB39E988BEFE45FC939AD33A7EF32353"
+                                        type: "item"
+                                        item: {
+                                                id: "create_central_kitchen:brewing_guide"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "71E8E65F4ED04A9198981C3854C57AAD"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "12D6E8D1072144A6898BAF8C6CBD4395"
+                        ]
+                },
+                {
+                        x: 10.0d
+                        y: 32.0d
+                        id: "5A2915A5DA5B497B8A75010084C0009F"
+                        title: "D\u00e9couverte : Create Enchantment Industry"
+                        icon: {
+                                id: "create_enchantment_industry:disenchanter"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "3199963DFE724781BF3854E9586B6654"
+                                        type: "item"
+                                        item: {
+                                                id: "create_enchantment_industry:disenchanter"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "0C76062201A44DEC887B1AC9C290EDA5"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "65C860B48A5945AB8947E26381CAA679"
+                        ]
+                },
+                {
+                        x: 10.0d
+                        y: 34.0d
+                        id: "E70F1EE05F2B4CDFAF7028069DCCCEA4"
+                        title: "Progression : Create Enchantment Industry"
+                        icon: {
+                                id: "create_enchantment_industry:enchanting_guide"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "A5482FA66E1045ADB8E0A68DE4628736"
+                                        type: "item"
+                                        item: {
+                                                id: "create_enchantment_industry:enchanting_guide"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "C79BD8C47A5540529CA30550F1A2F04F"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "5A2915A5DA5B497B8A75010084C0009F"
+                        ]
+                },
+                {
+                        x: 10.0d
+                        y: 36.0d
+                        id: "9C26A00504BA4627AAB4F2F4E2C92DB2"
+                        title: "Ma\u00eetrise : Create Enchantment Industry"
+                        icon: {
+                                id: "create_enchantment_industry:experience_rotor"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "B8041370DD4E4640843F885038D8C5ED"
+                                        type: "item"
+                                        item: {
+                                                id: "create_enchantment_industry:experience_rotor"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "6058D2DAD37A4C9AB5D64C5A0FADDE14"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "E70F1EE05F2B4CDFAF7028069DCCCEA4"
+                        ]
+                },
+                {
+                        x: 15.0d
+                        y: 32.0d
+                        id: "A5EF4D8E9410477CBA60930132FDA99A"
+                        title: "D\u00e9couverte : Createaddition"
+                        icon: {
+                                id: "createaddition:accumulator"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "AA0BEE735E3E4CC9A823492DE523FEC0"
+                                        type: "item"
+                                        item: {
+                                                id: "createaddition:accumulator"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "D7EDF3F4DAAC4998A5FB63D5CA2C0CBF"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "9C26A00504BA4627AAB4F2F4E2C92DB2"
+                        ]
+                },
+                {
+                        x: 15.0d
+                        y: 34.0d
+                        id: "26CC9F4A77D14231B35AF6A532FB1CF6"
+                        title: "Progression : Createaddition"
+                        icon: {
+                                id: "createaddition:alternator"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "1F6F641649C94963AAC63DE0FD70A8A7"
+                                        type: "item"
+                                        item: {
+                                                id: "createaddition:alternator"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "09C3ADDCAEAF4D129D742DA9F9423C51"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "A5EF4D8E9410477CBA60930132FDA99A"
+                        ]
+                },
+                {
+                        x: 15.0d
+                        y: 36.0d
+                        id: "2D014FB2FC33441C81C0F6BA1AF62E70"
+                        title: "Ma\u00eetrise : Createaddition"
+                        icon: {
+                                id: "createaddition:barbed_wire"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "861D1EC280A541508A87842B009F34BC"
+                                        type: "item"
+                                        item: {
+                                                id: "createaddition:barbed_wire"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "582D3FE0E1894E72A9D18D8F4B1A0A50"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "26CC9F4A77D14231B35AF6A532FB1CF6"
+                        ]
+                },
+                {
+                        x: 20.0d
+                        y: 32.0d
+                        id: "07D184C25B02470E8125B9AB0A71C57A"
+                        title: "D\u00e9couverte : Creativewirelesstransmitter"
+                        icon: {
+                                id: "creativewirelesstransmitter:black_creative_wireless_transmitter"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "A761C00E9B914BDCA973DD6E0F0FC241"
+                                        type: "item"
+                                        item: {
+                                                id: "creativewirelesstransmitter:black_creative_wireless_transmitter"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "8A29C38171E74C8FBC4BBCCFB8281B78"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "2D014FB2FC33441C81C0F6BA1AF62E70"
+                        ]
+                },
+                {
+                        x: 20.0d
+                        y: 34.0d
+                        id: "32D7382FD40D4535924CDEC7E081620E"
+                        title: "Progression : Creativewirelesstransmitter"
+                        icon: {
+                                id: "creativewirelesstransmitter:blue_creative_wireless_transmitter"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "4F129DAB42714405B39BAA6B9BF8FAA1"
+                                        type: "item"
+                                        item: {
+                                                id: "creativewirelesstransmitter:blue_creative_wireless_transmitter"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "36DB1B478EA4431FA2FFAB695FE5E3EB"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "07D184C25B02470E8125B9AB0A71C57A"
+                        ]
+                },
+                {
+                        x: 20.0d
+                        y: 36.0d
+                        id: "2315CF7B7B6A4AEDA3871E37BA079443"
+                        title: "Ma\u00eetrise : Creativewirelesstransmitter"
+                        icon: {
+                                id: "creativewirelesstransmitter:brown_creative_wireless_transmitter"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "750F8476EFDC45E08E30FF353E2EDFBD"
+                                        type: "item"
+                                        item: {
+                                                id: "creativewirelesstransmitter:brown_creative_wireless_transmitter"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "68C24A7C7B3A458480420846F00A5D82"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "32D7382FD40D4535924CDEC7E081620E"
+                        ]
+                },
+                {
+                        x: 25.0d
+                        y: 32.0d
+                        id: "0554DDAE51A4494A98C5DF02E7591B24"
+                        title: "D\u00e9couverte : Cyclic"
+                        icon: {
+                                id: "cyclic:altar_destruction"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "4C6DFA16039148648D58A29DA46BE140"
+                                        type: "item"
+                                        item: {
+                                                id: "cyclic:altar_destruction"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "0258F84F79144191A320B3B2E7A196FC"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "2315CF7B7B6A4AEDA3871E37BA079443"
+                        ]
+                },
+                {
+                        x: 25.0d
+                        y: 34.0d
+                        id: "D6420643519946D18916371C1A5D23C3"
+                        title: "Progression : Cyclic"
+                        icon: {
+                                id: "cyclic:amethyst_axe"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "38B290A97EA24F9ABF594A6ABEB8EA1E"
+                                        type: "item"
+                                        item: {
+                                                id: "cyclic:amethyst_axe"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "06C0883B51AD45939849BFDCCA5E8829"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "0554DDAE51A4494A98C5DF02E7591B24"
+                        ]
+                },
+                {
+                        x: 25.0d
+                        y: 36.0d
+                        id: "579AE843EA1B4A8BB0551CB1B4746DC6"
+                        title: "Ma\u00eetrise : Cyclic"
+                        icon: {
+                                id: "cyclic:amethyst_hoe"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "E17F715217B64931B588DE5F4E547BF3"
+                                        type: "item"
+                                        item: {
+                                                id: "cyclic:amethyst_hoe"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "1872D392BEF543CB999900DEF18AB2E4"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "D6420643519946D18916371C1A5D23C3"
+                        ]
+                },
+                {
+                        x: 0.0d
+                        y: 40.0d
+                        id: "3A38901A71864CD6A4EEF60E2CFE55C5"
+                        title: "D\u00e9couverte : Darkutilities Forge"
+                        icon: {
+                                id: "darkutils:alert_plate"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "84162E27699F4A6398AA9FD5343CA3A2"
+                                        type: "item"
+                                        item: {
+                                                id: "darkutils:alert_plate"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "50B91605A03F4350BB16E50C55965673"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "579AE843EA1B4A8BB0551CB1B4746DC6"
+                        ]
+                },
+                {
+                        x: 0.0d
+                        y: 42.0d
+                        id: "97353DEA8A9242ECA9A94730ECAE0626"
+                        title: "Progression : Darkutilities Forge"
+                        icon: {
+                                id: "darkutils:blank_plate"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "2DB9694D83A9446CB5770633461F9D5A"
+                                        type: "item"
+                                        item: {
+                                                id: "darkutils:blank_plate"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "8F0ECC3EBB3F411689DB0B742EC7E7BD"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "3A38901A71864CD6A4EEF60E2CFE55C5"
+                        ]
+                },
+                {
+                        x: 0.0d
+                        y: 44.0d
+                        id: "AEE9CE1D5A104741B2643082AFF05816"
+                        title: "Ma\u00eetrise : Darkutilities Forge"
+                        icon: {
+                                id: "darkutils:charm_experience"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "0EEE0C8AFA5740B5AD1FBA076952B230"
+                                        type: "item"
+                                        item: {
+                                                id: "darkutils:charm_experience"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "5F4A5E4261B3402B818301F86EB4A59B"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "97353DEA8A9242ECA9A94730ECAE0626"
+                        ]
+                },
+                {
+                        x: 5.0d
+                        y: 40.0d
+                        id: "1654B01CA0D6417AA036130D7F04F2A0"
+                        title: "D\u00e9couverte : Disenchantmentedittable"
+                        icon: {
+                                id: "editenchanting:enchantment_edit_table"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "8CE7218E1AAD4A7588578670B9230A58"
+                                        type: "item"
+                                        item: {
+                                                id: "editenchanting:enchantment_edit_table"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "AFAF900132194212BCB7236E4CF3D35A"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "AEE9CE1D5A104741B2643082AFF05816"
+                        ]
+                },
+                {
+                        x: 10.0d
+                        y: 40.0d
+                        id: "28C15E1730564122B2E7416A391B7E5A"
+                        title: "D\u00e9couverte : Draconic Evolution"
+                        icon: {
+                                id: "draconicevolution:advanced_dislocator"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "106204644ED1437BB2051A051A3D6AAE"
+                                        type: "item"
+                                        item: {
+                                                id: "draconicevolution:advanced_dislocator"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "1557600C035949108D4E94D80749A5A6"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "1654B01CA0D6417AA036130D7F04F2A0"
+                        ]
+                },
+                {
+                        x: 10.0d
+                        y: 42.0d
+                        id: "7A368F3CC5F54D03A13DA138D947F623"
+                        title: "Progression : Draconic Evolution"
+                        icon: {
+                                id: "draconicevolution:advanced_magnet"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "2EA05FC7991A4A56890C4AB8C67826DE"
+                                        type: "item"
+                                        item: {
+                                                id: "draconicevolution:advanced_magnet"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "B8CC9917EC9B4D7BABC32C66E7A6F846"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "28C15E1730564122B2E7416A391B7E5A"
+                        ]
+                },
+                {
+                        x: 10.0d
+                        y: 44.0d
+                        id: "883D33810FE548B8B36E93912F5FA765"
+                        title: "Ma\u00eetrise : Draconic Evolution"
+                        icon: {
+                                id: "draconicevolution:awakened_core"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "EB6E2DF1140E49E1861246DCD9994F08"
+                                        type: "item"
+                                        item: {
+                                                id: "draconicevolution:awakened_core"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "DB928E30558C4811903DF304A9A3BE74"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "7A368F3CC5F54D03A13DA138D947F623"
+                        ]
+                },
+                {
+                        x: 15.0d
+                        y: 40.0d
+                        id: "F34D648F3F784E4481F576AB37C91D13"
+                        title: "D\u00e9couverte : Enchantinginfuser V3.3.3"
+                        icon: {
+                                id: "enchantinginfuser:advanced_enchanting_infuser"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "F69C52C07EB44988AB2CAE4AB6AB589C"
+                                        type: "item"
+                                        item: {
+                                                id: "enchantinginfuser:advanced_enchanting_infuser"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "5237BDBA90CD4CCB8488F1A201572572"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "883D33810FE548B8B36E93912F5FA765"
+                        ]
+                },
+                {
+                        x: 15.0d
+                        y: 42.0d
+                        id: "6360B511C73E416286CAC8969E6D56F7"
+                        title: "Progression : Enchantinginfuser V3.3.3"
+                        icon: {
+                                id: "enchantinginfuser:enchanting_infuser"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "5345143BCFCC4E5280B46F200A288E2E"
+                                        type: "item"
+                                        item: {
+                                                id: "enchantinginfuser:enchanting_infuser"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "E46724FFE4CC4262A362C6DA2A1DE986"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "F34D648F3F784E4481F576AB37C91D13"
+                        ]
+                },
+                {
+                        x: 20.0d
+                        y: 40.0d
+                        id: "28A15C05DE7649BEBC92DA9905E6A7BC"
+                        title: "D\u00e9couverte : Exchangers"
+                        icon: {
+                                id: "exchangers:advanced_exchanger"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "F0C246D97A7143C2975123A4A602215B"
+                                        type: "item"
+                                        item: {
+                                                id: "exchangers:advanced_exchanger"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "A504CF6E42904538818FE5D3D9C5D371"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "6360B511C73E416286CAC8969E6D56F7"
+                        ]
+                },
+                {
+                        x: 20.0d
+                        y: 42.0d
+                        id: "299EA0F02C5E401BB6FB75D590691286"
+                        title: "Progression : Exchangers"
+                        icon: {
+                                id: "exchangers:amethyst_exchanger"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "63580376BB434B3AB4116EF56C6A5F47"
+                                        type: "item"
+                                        item: {
+                                                id: "exchangers:amethyst_exchanger"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "FA1F84C546244DB5A110A83BBDFD958E"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "28A15C05DE7649BEBC92DA9905E6A7BC"
+                        ]
+                },
+                {
+                        x: 20.0d
+                        y: 44.0d
+                        id: "0B9591BCA97C43A7B11294CC27304533"
+                        title: "Ma\u00eetrise : Exchangers"
+                        icon: {
+                                id: "exchangers:basic_exchanger"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "FAF68FB4780B4F828A380BFAE978FCFF"
+                                        type: "item"
+                                        item: {
+                                                id: "exchangers:basic_exchanger"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "23FBB847E1224324870923BB04AE05E8"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "299EA0F02C5E401BB6FB75D590691286"
+                        ]
+                },
+                {
+                        x: 25.0d
+                        y: 40.0d
+                        id: "82AE854144034D6C89147F849F3E5385"
+                        title: "D\u00e9couverte : Extremereactors2"
+                        icon: {
+                                id: "bigreactors:anglesite_crystal"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "FB06B7C67806467A862D8A43D1400931"
+                                        type: "item"
+                                        item: {
+                                                id: "bigreactors:anglesite_crystal"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "127EEF12CF824E6CA88D1F85B94DD9C6"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "0B9591BCA97C43A7B11294CC27304533"
+                        ]
+                },
+                {
+                        x: 25.0d
+                        y: 42.0d
+                        id: "3F67ABF1A35C474EABB4E7F3CC973753"
+                        title: "Progression : Extremereactors2"
+                        icon: {
+                                id: "bigreactors:anglesite_ore"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "97F780850EAE4AFFBFE0EA44B0D84B0C"
+                                        type: "item"
+                                        item: {
+                                                id: "bigreactors:anglesite_ore"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "729938BCBF5D4B2181386F9B19905B1D"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "82AE854144034D6C89147F849F3E5385"
+                        ]
+                },
+                {
+                        x: 25.0d
+                        y: 44.0d
+                        id: "F0FE9EF5930C4D7A8F93A7350061DA00"
+                        title: "Ma\u00eetrise : Extremereactors2"
+                        icon: {
+                                id: "bigreactors:basic_reactorcasing"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "2F70FFA120904C0CB594511AB50FA2CE"
+                                        type: "item"
+                                        item: {
+                                                id: "bigreactors:basic_reactorcasing"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "12611A6CAC034C4B86F73976E4F965CE"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "3F67ABF1A35C474EABB4E7F3CC973753"
+                        ]
+                },
+                {
+                        x: 0.0d
+                        y: 48.0d
+                        id: "04970C2D58464927A5BA750A6E0DE27C"
+                        title: "D\u00e9couverte : Fluxnetworks"
+                        icon: {
+                                id: "fluxnetworks:admin_configurator"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "C4A79515361641858A21EC4476140F00"
+                                        type: "item"
+                                        item: {
+                                                id: "fluxnetworks:admin_configurator"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "6447B62110EE4C51AF8531F7E272AE98"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "F0FE9EF5930C4D7A8F93A7350061DA00"
+                        ]
+                },
+                {
+                        x: 0.0d
+                        y: 50.0d
+                        id: "E822E98FF6834BCAB1E3A1EBDF887780"
+                        title: "Progression : Fluxnetworks"
+                        icon: {
+                                id: "fluxnetworks:basic_flux_storage"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "7B0EFC71F1EA4BFD8FE425A9193298C4"
+                                        type: "item"
+                                        item: {
+                                                id: "fluxnetworks:basic_flux_storage"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "A13945392A0B486E99D58928E04CDACD"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "04970C2D58464927A5BA750A6E0DE27C"
+                        ]
+                },
+                {
+                        x: 0.0d
+                        y: 52.0d
+                        id: "D46BEFA80A224227BE0C80D1BCEC770B"
+                        title: "Ma\u00eetrise : Fluxnetworks"
+                        icon: {
+                                id: "fluxnetworks:flux_block"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "7E12C51330104106BC848CD56FD827E3"
+                                        type: "item"
+                                        item: {
+                                                id: "fluxnetworks:flux_block"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "CEBA544A4EF7409E9D076E660B718790"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "E822E98FF6834BCAB1E3A1EBDF887780"
+                        ]
+                },
+                {
+                        x: 5.0d
+                        y: 48.0d
+                        id: "3D1EF5F1E9FC4342B34DA2CCE1AF169F"
+                        title: "D\u00e9couverte : Fossil Forge"
+                        icon: {
+                                id: "fossil:alligator_gar_dna"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "36D8F8E1F9D0433DABDA7A245DC30663"
+                                        type: "item"
+                                        item: {
+                                                id: "fossil:alligator_gar_dna"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "D303723C6DEB44A6B6E0BE50D9558BDE"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "D46BEFA80A224227BE0C80D1BCEC770B"
+                        ]
+                },
+                {
+                        x: 5.0d
+                        y: 50.0d
+                        id: "CE6EC981EC1446659077D6D9DC8E3DD8"
+                        title: "Progression : Fossil Forge"
+                        icon: {
+                                id: "fossil:allosaurus_dna"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "349B5DA857E5423F932A965D94673F3A"
+                                        type: "item"
+                                        item: {
+                                                id: "fossil:allosaurus_dna"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "027BC34615B7403F9214153F35BEDC81"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "3D1EF5F1E9FC4342B34DA2CCE1AF169F"
+                        ]
+                },
+                {
+                        x: 5.0d
+                        y: 52.0d
+                        id: "27A5276CC5FC43549140C6436BA57311"
+                        title: "Ma\u00eetrise : Fossil Forge"
+                        icon: {
+                                id: "fossil:amber_block"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "12CC64F1D4F44E8BA2C0804D9F80BA4D"
+                                        type: "item"
+                                        item: {
+                                                id: "fossil:amber_block"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "82B7FF6392814F70940E2D265129BBB6"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "CE6EC981EC1446659077D6D9DC8E3DD8"
+                        ]
+                },
+                {
+                        x: 10.0d
+                        y: 48.0d
+                        id: "4463D895878E4336BB939B41AC6EC96D"
+                        title: "D\u00e9couverte : Framedblocks"
+                        icon: {
+                                id: "framedblocks:framed_activator_rail_slope"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "78EDC4205D4D4C48AC552B2E3F9E180F"
+                                        type: "item"
+                                        item: {
+                                                id: "framedblocks:framed_activator_rail_slope"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "6F5B3B164BEC4BFB832F44AFAF32E11B"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "27A5276CC5FC43549140C6436BA57311"
+                        ]
+                },
+                {
+                        x: 10.0d
+                        y: 50.0d
+                        id: "0F3847170A424E30B710D651EE62DF97"
+                        title: "Progression : Framedblocks"
+                        icon: {
+                                id: "framedblocks:framed_bars"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "6B76BD263ECD433B814C28417DAFCCFC"
+                                        type: "item"
+                                        item: {
+                                                id: "framedblocks:framed_bars"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "11C2BBADE7F6477D81E454F1ADF978C7"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "4463D895878E4336BB939B41AC6EC96D"
+                        ]
+                },
+                {
+                        x: 10.0d
+                        y: 52.0d
+                        id: "D232A4E6642F4EA69172650CFB66973C"
+                        title: "Ma\u00eetrise : Framedblocks"
+                        icon: {
+                                id: "framedblocks:framed_blueprint"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "55D0C7F91E804D9C9BFCA92ACCAEA5CF"
+                                        type: "item"
+                                        item: {
+                                                id: "framedblocks:framed_blueprint"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "6E00D83B92ED48C9B3D4DE3813DE3F99"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "0F3847170A424E30B710D651EE62DF97"
+                        ]
+                },
+                {
+                        x: 15.0d
+                        y: 48.0d
+                        id: "1EC0E1C84D2540F2BC909B1D1912C180"
+                        title: "D\u00e9couverte : Ftb Library Forge"
+                        icon: {
+                                id: "ftblibrary:fluid_container"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "C2821CE92E7445328C84463BC5CF3F5D"
+                                        type: "item"
+                                        item: {
+                                                id: "ftblibrary:fluid_container"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "EF032FE655A3476C8E62F2B846974E8B"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "D232A4E6642F4EA69172650CFB66973C"
+                        ]
+                },
+                {
+                        x: 20.0d
+                        y: 48.0d
+                        id: "7E1DB1612C0E4673AA321A96EBEBEAC6"
+                        title: "D\u00e9couverte : Ftb Ultimine Forge"
+                        icon: {
+                                id: "ftbultimine:ultiminer"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "C87747861FD347ECA093E7B7B2CFCEE7"
+                                        type: "item"
+                                        item: {
+                                                id: "ftbultimine:ultiminer"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "AD9C9DA1471A42D79D66F9C2AA00B703"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "1EC0E1C84D2540F2BC909B1D1912C180"
+                        ]
+                },
+                {
+                        x: 25.0d
+                        y: 48.0d
+                        id: "05A04AD9399D44848AF1D4405ECE9BC9"
+                        title: "D\u00e9couverte : Geckolib Forge"
+                        icon: {
+                                id: "geckolib3:botarium"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "0956A190C1B54B8DA2D9B302FB2CBAB8"
+                                        type: "item"
+                                        item: {
+                                                id: "geckolib3:botarium"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "847B714D8C864B6D82E72BEEA85BBB86"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "7E1DB1612C0E4673AA321A96EBEBEAC6"
+                        ]
+                },
+                {
+                        x: 25.0d
+                        y: 50.0d
+                        id: "90FB3FB52D6E48A7B397B5886B9D3CB6"
+                        title: "Progression : Geckolib Forge"
+                        icon: {
+                                id: "geckolib3:botariumblock"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "86B44CEEDE32497C8CCCDA6C8A05D9C9"
+                                        type: "item"
+                                        item: {
+                                                id: "geckolib3:botariumblock"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "C8AB6130BADF48A2B571F1131CF34E9D"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "05A04AD9399D44848AF1D4405ECE9BC9"
+                        ]
+                },
+                {
+                        x: 25.0d
+                        y: 52.0d
+                        id: "751B29B010924E67AA4F647844F99603"
+                        title: "Ma\u00eetrise : Geckolib Forge"
+                        icon: {
+                                id: "geckolib3:fertilizer"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "E088B4AEC6944113A46CADD721595CF1"
+                                        type: "item"
+                                        item: {
+                                                id: "geckolib3:fertilizer"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "9554F198DD90438A9C0C510D196E95E7"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "90FB3FB52D6E48A7B397B5886B9D3CB6"
+                        ]
+                },
+                {
+                        x: 0.0d
+                        y: 56.0d
+                        id: "CC67D4BB03CF45D68299940C4D56EEFC"
+                        title: "D\u00e9couverte : Guardvillagers"
+                        icon: {
+                                id: "guardvillagers:guard_spawn_egg"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "01A07FBD6D7B4FCC90597165B37ED96B"
+                                        type: "item"
+                                        item: {
+                                                id: "guardvillagers:guard_spawn_egg"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "3A6D2E486098443BA1A7F70BCED67CF1"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "751B29B010924E67AA4F647844F99603"
+                        ]
+                },
+                {
+                        x: 0.0d
+                        y: 58.0d
+                        id: "C3F039C47F8C4BDA9E425ED9AE5327AB"
+                        title: "Progression : Guardvillagers"
+                        icon: {
+                                id: "guardvillagers:illusioner_spawn_egg"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "DB694D5312A7499798D923861559FF55"
+                                        type: "item"
+                                        item: {
+                                                id: "guardvillagers:illusioner_spawn_egg"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "CBB8FDDEDA5748638B745CA1E54DE1AB"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "CC67D4BB03CF45D68299940C4D56EEFC"
+                        ]
+                },
+                {
+                        x: 0.0d
+                        y: 60.0d
+                        id: "7ED4B7850F2B4FA3BF9833C908293C7A"
+                        title: "Ma\u00eetrise : Guardvillagers"
+                        icon: {
+                                id: "guardvillagers:iron_golem_spawn_egg"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "52DDE61A013A4A9A9E0B15C24C3B19B5"
+                                        type: "item"
+                                        item: {
+                                                id: "guardvillagers:iron_golem_spawn_egg"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "77DC9C2AE6274F948034ED903D0D7418"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "C3F039C47F8C4BDA9E425ED9AE5327AB"
+                        ]
+                },
+                {
+                        x: 5.0d
+                        y: 56.0d
+                        id: "17F03CD896C14AD7B99D9E7E1ECB36CE"
+                        title: "D\u00e9couverte : Hammerlib"
+                        icon: {
+                                id: "hammerlib:test_machine"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "C06711D67D2A40A9A5523274D3CD9A35"
+                                        type: "item"
+                                        item: {
+                                                id: "hammerlib:test_machine"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "8B008C368DEB45BBB0F38BBB22FAA4D4"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "7ED4B7850F2B4FA3BF9833C908293C7A"
+                        ]
+                },
+                {
+                        x: 5.0d
+                        y: 58.0d
+                        id: "66CE1DBD5A804301BD5E309D08525020"
+                        title: "Progression : Hammerlib"
+                        icon: {
+                                id: "hammerlib:wrench"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "9909A3276F344CF094699492D3784266"
+                                        type: "item"
+                                        item: {
+                                                id: "hammerlib:wrench"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "1603F8D27C9440F7BA1455BE236A975F"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "17F03CD896C14AD7B99D9E7E1ECB36CE"
+                        ]
+                },
+                {
+                        x: 10.0d
+                        y: 56.0d
+                        id: "75788D083FC44E02BD98BF10C205EEF2"
+                        title: "D\u00e9couverte : Hole Filler Mod"
+                        icon: {
+                                id: "hole_filler_mod:curing_block"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "C0F426DF397B4F219959D2D64DEF4540"
+                                        type: "item"
+                                        item: {
+                                                id: "hole_filler_mod:curing_block"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "511A730D48AA4577A78AB6C261639130"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "66CE1DBD5A804301BD5E309D08525020"
+                        ]
+                },
+                {
+                        x: 10.0d
+                        y: 58.0d
+                        id: "3E4C72F2246E42399BE72D2EA6537CEC"
+                        title: "Progression : Hole Filler Mod"
+                        icon: {
+                                id: "hole_filler_mod:hole_filler_block"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "D38D2A3C0EB84139824B85CDF4A722AF"
+                                        type: "item"
+                                        item: {
+                                                id: "hole_filler_mod:hole_filler_block"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "A2BAF5501D6747E2B976AF3087265EAF"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "75788D083FC44E02BD98BF10C205EEF2"
+                        ]
+                },
+                {
+                        x: 10.0d
+                        y: 60.0d
+                        id: "1D33426FE4024E6DAF7F5C1EFC6914E2"
+                        title: "Ma\u00eetrise : Hole Filler Mod"
+                        icon: {
+                                id: "hole_filler_mod:hole_filler_block_balanced"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "3A7F2AD4D87540BF986D1DD815693375"
+                                        type: "item"
+                                        item: {
+                                                id: "hole_filler_mod:hole_filler_block_balanced"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "517B1590204C49299A7735FBB4F505A2"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "3E4C72F2246E42399BE72D2EA6537CEC"
+                        ]
+                },
+                {
+                        x: 15.0d
+                        y: 56.0d
+                        id: "8A728D4DACA24615908A32D07D3C6B79"
+                        title: "D\u00e9couverte : Idas Forge"
+                        icon: {
+                                id: "idas:disc_fragment_slither"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "F10D4359AFB34E0CACA841A4854B526C"
+                                        type: "item"
+                                        item: {
+                                                id: "idas:disc_fragment_slither"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "C669C557C1214CE68FB3BC6BCD7F0DB8"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "1D33426FE4024E6DAF7F5C1EFC6914E2"
+                        ]
+                },
+                {
+                        x: 15.0d
+                        y: 58.0d
+                        id: "6D49BE8CABCF4DF68C4A1E5C2E317C8C"
+                        title: "Progression : Idas Forge"
+                        icon: {
+                                id: "idas:music_disc_calidum"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "A068CE56F429472289E9AD3D69C6D981"
+                                        type: "item"
+                                        item: {
+                                                id: "idas:music_disc_calidum"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "A692CE8CF50148299223A5CD5DFD3C15"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "8A728D4DACA24615908A32D07D3C6B79"
+                        ]
+                },
+                {
+                        x: 15.0d
+                        y: 60.0d
+                        id: "45824B75A45D4F709645A894BF0AEF82"
+                        title: "Ma\u00eetrise : Idas Forge"
+                        icon: {
+                                id: "idas:music_disc_slither"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "B54233A5E5BC4A7FB3B1A21A9923FB62"
+                                        type: "item"
+                                        item: {
+                                                id: "idas:music_disc_slither"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "6688237FAC0E443E9D5AD0B0128B636A"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "6D49BE8CABCF4DF68C4A1E5C2E317C8C"
+                        ]
+                },
+                {
+                        x: 20.0d
+                        y: 56.0d
+                        id: "1ED860CAA4EB43FA8411247F024F0018"
+                        title: "D\u00e9couverte : Immersive Weathering"
+                        icon: {
+                                id: "immersive_weathering:acacia_bark"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "746AA159A55E46928AF13677CB1D3251"
+                                        type: "item"
+                                        item: {
+                                                id: "immersive_weathering:acacia_bark"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "1A7757A78C6C4EC6BB9C7D1C41E769FE"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "45824B75A45D4F709645A894BF0AEF82"
+                        ]
+                },
+                {
+                        x: 20.0d
+                        y: 58.0d
+                        id: "99BE191E52A741D7B24008396F7D8098"
+                        title: "Progression : Immersive Weathering"
+                        icon: {
+                                id: "immersive_weathering:acacia_leaf_pile"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "2973279BC4B64BAFBCAA3F28E7F263A0"
+                                        type: "item"
+                                        item: {
+                                                id: "immersive_weathering:acacia_leaf_pile"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "C705BEF79BA842A4B65C28231ABDFBF9"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "1ED860CAA4EB43FA8411247F024F0018"
+                        ]
+                },
+                {
+                        x: 20.0d
+                        y: 60.0d
+                        id: "4160633CBC014E8BBB439BF0D611F5F0"
+                        title: "Ma\u00eetrise : Immersive Weathering"
+                        icon: {
+                                id: "immersive_weathering:ash_block"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "9C57A1B6424B4D7E928AE72BB265F083"
+                                        type: "item"
+                                        item: {
+                                                id: "immersive_weathering:ash_block"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "B79C2FF78F1A4BB9B4130284A2A1F45D"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "99BE191E52A741D7B24008396F7D8098"
+                        ]
+                },
+                {
+                        x: 25.0d
+                        y: 56.0d
+                        id: "88B97CAF4399485189AF52B9B81B9998"
+                        title: "D\u00e9couverte : Ironchest"
+                        icon: {
+                                id: "ironchest:copper_chest"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "87DBCF275EC24054B6CCE5CA10D40D8D"
+                                        type: "item"
+                                        item: {
+                                                id: "ironchest:copper_chest"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "F611A4C9639E4E1A8FAC736F0988482F"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "4160633CBC014E8BBB439BF0D611F5F0"
+                        ]
+                },
+                {
+                        x: 25.0d
+                        y: 58.0d
+                        id: "3F17AC65859F41D9BC077DD17A237BF7"
+                        title: "Progression : Ironchest"
+                        icon: {
+                                id: "ironchest:copper_to_iron_chest_upgrade"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "E25005C6BB794012B1C017F87BBF5B33"
+                                        type: "item"
+                                        item: {
+                                                id: "ironchest:copper_to_iron_chest_upgrade"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "EC45EAC907D649EB9EEB59B3D26F7597"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "88B97CAF4399485189AF52B9B81B9998"
+                        ]
+                },
+                {
+                        x: 25.0d
+                        y: 60.0d
+                        id: "A422D1DC817A4F29AF80F860FE8E5B93"
+                        title: "Ma\u00eetrise : Ironchest"
+                        icon: {
+                                id: "ironchest:crystal_chest"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "DFACDFA85D5F4DBA99398AD089718FBF"
+                                        type: "item"
+                                        item: {
+                                                id: "ironchest:crystal_chest"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "B2C0876BF0FE48C3BC57949DD25DEA46"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "3F17AC65859F41D9BC077DD17A237BF7"
+                        ]
+                },
+                {
+                        x: 0.0d
+                        y: 64.0d
+                        id: "FC18611F28E74050A63395D4497A2826"
+                        title: "D\u00e9couverte : Ironfurnaces"
+                        icon: {
+                                id: "ironfurnaces:allthemodium_furnace"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "C53265AE6AAF4C028508F8E6329DA2AF"
+                                        type: "item"
+                                        item: {
+                                                id: "ironfurnaces:allthemodium_furnace"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "A52F388AED3640EEAE1A0C4BA7E0FC97"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "A422D1DC817A4F29AF80F860FE8E5B93"
+                        ]
+                },
+                {
+                        x: 0.0d
+                        y: 66.0d
+                        id: "A90D5B8449544D4780779E82FCFBD0D2"
+                        title: "Progression : Ironfurnaces"
+                        icon: {
+                                id: "ironfurnaces:augment_blasting"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "D44DA1B4E0ED459790E3955E0214F60F"
+                                        type: "item"
+                                        item: {
+                                                id: "ironfurnaces:augment_blasting"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "B27A2924B89540448D6A1C0180A780AB"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "FC18611F28E74050A63395D4497A2826"
+                        ]
+                },
+                {
+                        x: 0.0d
+                        y: 68.0d
+                        id: "4F761B29116D4D8B84B33CE763CE6D0E"
+                        title: "Ma\u00eetrise : Ironfurnaces"
+                        icon: {
+                                id: "ironfurnaces:augment_factory"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "2AB2F5EBBE6947379AC7FBB9A51C1212"
+                                        type: "item"
+                                        item: {
+                                                id: "ironfurnaces:augment_factory"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "8EB6BDE81E824F41BC8D652D3CF9F435"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "A90D5B8449544D4780779E82FCFBD0D2"
+                        ]
+                },
+                {
+                        x: 5.0d
+                        y: 64.0d
+                        id: "1063FFE765E14E9F9EE9AFF6A7C77D88"
+                        title: "D\u00e9couverte : Item Filters Forge"
+                        icon: {
+                                id: "itemfilters:always_false"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "00D87E175B504A8BB0623CEDD1132C31"
+                                        type: "item"
+                                        item: {
+                                                id: "itemfilters:always_false"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "E45C0D082482421588D763842D7D1836"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "4F761B29116D4D8B84B33CE763CE6D0E"
+                        ]
+                },
+                {
+                        x: 5.0d
+                        y: 66.0d
+                        id: "B5C3686E682C42F6AC08F9F1DDE61C14"
+                        title: "Progression : Item Filters Forge"
+                        icon: {
+                                id: "itemfilters:always_true"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "EBDBE5A213CB4A1E8360FEE3CD6A6014"
+                                        type: "item"
+                                        item: {
+                                                id: "itemfilters:always_true"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "0B43E3F92105411C92D058C2EE9F41E0"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "1063FFE765E14E9F9EE9AFF6A7C77D88"
+                        ]
+                },
+                {
+                        x: 5.0d
+                        y: 68.0d
+                        id: "0906F97F8D1E4F4099AB5B0071C60811"
+                        title: "Ma\u00eetrise : Item Filters Forge"
+                        icon: {
+                                id: "itemfilters:and"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "A2176E5EB84F493F80731F27268A8B86"
+                                        type: "item"
+                                        item: {
+                                                id: "itemfilters:and"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "2FC0AC4252C74234B9A20621C5CDF3F0"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "B5C3686E682C42F6AC08F9F1DDE61C14"
+                        ]
+                },
+                {
+                        x: 10.0d
+                        y: 64.0d
+                        id: "3F81ED54EAA14A7F82BBA9D49463131B"
+                        title: "D\u00e9couverte : Justhammers Forge"
+                        icon: {
+                                id: "justhammers:destructor_core"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "E380FA19232B4868A8E73BD19D7312DF"
+                                        type: "item"
+                                        item: {
+                                                id: "justhammers:destructor_core"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "C40D782A96D9478CB66F37FD1AFD40C0"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "0906F97F8D1E4F4099AB5B0071C60811"
+                        ]
+                },
+                {
+                        x: 10.0d
+                        y: 66.0d
+                        id: "873918F7E5414B5785A5ADA1875D2B51"
+                        title: "Progression : Justhammers Forge"
+                        icon: {
+                                id: "justhammers:diamond_destructor_hammer"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "04CE87137CD64194B606AD961D989137"
+                                        type: "item"
+                                        item: {
+                                                id: "justhammers:diamond_destructor_hammer"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "70A7B028A9584603B1268BFF8E426EDF"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "3F81ED54EAA14A7F82BBA9D49463131B"
+                        ]
+                },
+                {
+                        x: 10.0d
+                        y: 68.0d
+                        id: "0C6E3AB6A4BA4966A2EA70392825132D"
+                        title: "Ma\u00eetrise : Justhammers Forge"
+                        icon: {
+                                id: "justhammers:diamond_hammer"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "C929BEBBA3894208ACBB20D927B450C6"
+                                        type: "item"
+                                        item: {
+                                                id: "justhammers:diamond_hammer"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "80E8F849FCC945BDAAF31545A32968DE"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "873918F7E5414B5785A5ADA1875D2B51"
+                        ]
+                },
+                {
+                        x: 15.0d
+                        y: 64.0d
+                        id: "22FE3CA045DD487E8981D4F9D9F6E192"
+                        title: "D\u00e9couverte : Libraryferret Forge"
+                        icon: {
+                                id: "libraryferret:diamond_coins_jtl"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "8DCA2DEF54F646BBAD39C15AED80D4B7"
+                                        type: "item"
+                                        item: {
+                                                id: "libraryferret:diamond_coins_jtl"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "808E6FCE5A284343B9F9E26446C36609"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "0C6E3AB6A4BA4966A2EA70392825132D"
+                        ]
+                },
+                {
+                        x: 15.0d
+                        y: 66.0d
+                        id: "4AD7B3B442ED41938E60444C34A819BF"
+                        title: "Progression : Libraryferret Forge"
+                        icon: {
+                                id: "libraryferret:emerald_coins_jtl"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "1BFD290D18CF45A8B4007D96A0E07D39"
+                                        type: "item"
+                                        item: {
+                                                id: "libraryferret:emerald_coins_jtl"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "2504818331184F56915033CB6A1B17D0"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "22FE3CA045DD487E8981D4F9D9F6E192"
+                        ]
+                },
+                {
+                        x: 15.0d
+                        y: 68.0d
+                        id: "AB74B68766834D1BA3EE34F114517A3A"
+                        title: "Ma\u00eetrise : Libraryferret Forge"
+                        icon: {
+                                id: "libraryferret:fake_diamond_block"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "C8632FD40A934330A545BCC4C352035A"
+                                        type: "item"
+                                        item: {
+                                                id: "libraryferret:fake_diamond_block"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "BE225EFAEAD94A52B056E3BFFBFFFEA2"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "4AD7B3B442ED41938E60444C34A819BF"
+                        ]
+                },
+                {
+                        x: 20.0d
+                        y: 64.0d
+                        id: "611CE82BFF9142429C8A0C47C65A786C"
+                        title: "D\u00e9couverte : Lootr Forge"
+                        icon: {
+                                id: "lootr:crown"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "2A349AF6A8B94C84A89B2CEA9302FEFB"
+                                        type: "item"
+                                        item: {
+                                                id: "lootr:crown"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "16615D4E36D5476E8ED47445E69AF196"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "AB74B68766834D1BA3EE34F114517A3A"
+                        ]
+                },
+                {
+                        x: 20.0d
+                        y: 66.0d
+                        id: "7E3736F9863943FDBC884415F63FB1FB"
+                        title: "Progression : Lootr Forge"
+                        icon: {
+                                id: "lootr:lootr_barrel"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "A2C3EF5B2DDC47F0A7BB4D7FD062F561"
+                                        type: "item"
+                                        item: {
+                                                id: "lootr:lootr_barrel"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "F082B128F811423EBB6857A3CDC710EF"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "611CE82BFF9142429C8A0C47C65A786C"
+                        ]
+                },
+                {
+                        x: 20.0d
+                        y: 68.0d
+                        id: "E8CE678FD02A4176BD20B520A81F6D03"
+                        title: "Ma\u00eetrise : Lootr Forge"
+                        icon: {
+                                id: "lootr:lootr_chest"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "8E9DCC97100D409C97414C3B89B8249A"
+                                        type: "item"
+                                        item: {
+                                                id: "lootr:lootr_chest"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "A67F450A107C4290BF897A47D505246D"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "7E3736F9863943FDBC884415F63FB1FB"
+                        ]
+                },
+                {
+                        x: 25.0d
+                        y: 64.0d
+                        id: "C2B23CD2DEEF4D8C921B2E03862F8141"
+                        title: "D\u00e9couverte : Luxury Furnitures 2.29.0 1.18.2"
+                        icon: {
+                                id: "luxuryfurnitures:acindoorunit"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "0FD5B29B91764749B4071D518A675D64"
+                                        type: "item"
+                                        item: {
+                                                id: "luxuryfurnitures:acindoorunit"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "64BA78CA396C4096BDD80E8F1CC1BC52"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "E8CE678FD02A4176BD20B520A81F6D03"
+                        ]
+                },
+                {
+                        x: 25.0d
+                        y: 66.0d
+                        id: "986CB5EFDA4346F18469AD85B61A1B41"
+                        title: "Progression : Luxury Furnitures 2.29.0 1.18.2"
+                        icon: {
+                                id: "luxuryfurnitures:acoutdoorunit"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "7F804C0E48E045B4897E76C698253073"
+                                        type: "item"
+                                        item: {
+                                                id: "luxuryfurnitures:acoutdoorunit"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "24C57737FEBA4A02924D19D5DE188351"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "C2B23CD2DEEF4D8C921B2E03862F8141"
+                        ]
+                },
+                {
+                        x: 25.0d
+                        y: 68.0d
+                        id: "F3A84CC0F8814FF197B6D45B8EDC9F6B"
+                        title: "Ma\u00eetrise : Luxury Furnitures 2.29.0 1.18.2"
+                        icon: {
+                                id: "luxuryfurnitures:airfryer"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "05D5E5439C084196991B407D5A6C3F0E"
+                                        type: "item"
+                                        item: {
+                                                id: "luxuryfurnitures:airfryer"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "0941F59C96594EDDA85ABB8799BE98D8"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "986CB5EFDA4346F18469AD85B61A1B41"
+                        ]
+                },
+                {
+                        x: 0.0d
+                        y: 72.0d
+                        id: "CE89280680F94B658075B09425FB9B67"
+                        title: "D\u00e9couverte : Mapperbase"
+                        icon: {
+                                id: "mapperbase:bolt"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "6435013D01004568B617770D6D5884F7"
+                                        type: "item"
+                                        item: {
+                                                id: "mapperbase:bolt"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "6F986039BF564154B0656EC97DD56F23"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "F3A84CC0F8814FF197B6D45B8EDC9F6B"
+                        ]
+                },
+                {
+                        x: 0.0d
+                        y: 74.0d
+                        id: "08F1E4824D584F1FA66B3ACDCF49A37D"
+                        title: "Progression : Mapperbase"
+                        icon: {
+                                id: "mapperbase:ferrite"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "10E879F341E74E10AAA83D0DF4F781D9"
+                                        type: "item"
+                                        item: {
+                                                id: "mapperbase:ferrite"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "A84136E3F6E54471B5839D5955C1CCB0"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "CE89280680F94B658075B09425FB9B67"
+                        ]
+                },
+                {
+                        x: 0.0d
+                        y: 76.0d
+                        id: "97EE6A7E00444A6C8737BC80FAD5E935"
+                        title: "Ma\u00eetrise : Mapperbase"
+                        icon: {
+                                id: "mapperbase:flatter_hammer"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "51B96421CDC34ACD95DBF6F6F9738898"
+                                        type: "item"
+                                        item: {
+                                                id: "mapperbase:flatter_hammer"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "12F31AFD48994DCE8483745A24415D71"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "08F1E4824D584F1FA66B3ACDCF49A37D"
+                        ]
+                },
+                {
+                        x: 5.0d
+                        y: 72.0d
+                        id: "8FAD09A63A904F869B90B116ED2A5FFE"
+                        title: "D\u00e9couverte : Mcjtylib"
+                        icon: {
+                                id: "mcjtylib:multipart"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "EE243107B5234451909F7DC14CF31294"
+                                        type: "item"
+                                        item: {
+                                                id: "mcjtylib:multipart"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "4C0AEE67B8CE406F9D268814748A2DFF"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "97EE6A7E00444A6C8737BC80FAD5E935"
+                        ]
+                },
+                {
+                        x: 10.0d
+                        y: 72.0d
+                        id: "4E12BEBABEB045638E17B377E72EDFEA"
+                        title: "D\u00e9couverte : Mcmodded"
+                        icon: {
+                                id: "mcmodded:black_brick"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "19AE133145F94621920DDFCFCFF2A5C4"
+                                        type: "item"
+                                        item: {
+                                                id: "mcmodded:black_brick"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "46F706920B5E4663935F65D7AB160639"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "8FAD09A63A904F869B90B116ED2A5FFE"
+                        ]
+                },
+                {
+                        x: 10.0d
+                        y: 74.0d
+                        id: "7507F13B10A24DA19588741350B3579A"
+                        title: "Progression : Mcmodded"
+                        icon: {
+                                id: "mcmodded:black_textured"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "089D54ABFB064FAA897CA13C47ABDAB6"
+                                        type: "item"
+                                        item: {
+                                                id: "mcmodded:black_textured"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "EDCEA816FDED4056B9C2E863CEF58FA7"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "4E12BEBABEB045638E17B377E72EDFEA"
+                        ]
+                },
+                {
+                        x: 10.0d
+                        y: 76.0d
+                        id: "68FE21E7CE6B40F29232643973D49EC5"
+                        title: "Ma\u00eetrise : Mcmodded"
+                        icon: {
+                                id: "mcmodded:cave_block"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "C5ED14B680FA498DAB71D5EA5A5E1F58"
+                                        type: "item"
+                                        item: {
+                                                id: "mcmodded:cave_block"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "43054AC78DAC45A9A077F9B09D77F71D"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "7507F13B10A24DA19588741350B3579A"
+                        ]
+                },
+                {
+                        x: 15.0d
+                        y: 72.0d
+                        id: "A919242D056446AEB1DFC82DA49D7218"
+                        title: "D\u00e9couverte : Mcw Bridges"
+                        icon: {
+                                id: "mcwbridges:acacia_bridge_pier"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "7C38FC1BE64445A88D10F3C1CC362B82"
+                                        type: "item"
+                                        item: {
+                                                id: "mcwbridges:acacia_bridge_pier"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "9BAA30201C5A499F9C55E7B93A7D0E3F"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "68FE21E7CE6B40F29232643973D49EC5"
+                        ]
+                },
+                {
+                        x: 15.0d
+                        y: 74.0d
+                        id: "8EB0489D923D472BA169E640E71A2BD8"
+                        title: "Progression : Mcw Bridges"
+                        icon: {
+                                id: "mcwbridges:acacia_log_bridge_middle"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "012B10347A8B4986B38CA4307A6CEB6D"
+                                        type: "item"
+                                        item: {
+                                                id: "mcwbridges:acacia_log_bridge_middle"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "B904A927724848BA8A66F659B46D9F75"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "A919242D056446AEB1DFC82DA49D7218"
+                        ]
+                },
+                {
+                        x: 15.0d
+                        y: 76.0d
+                        id: "96AE7F8DA6894512B1DDCAC6DDC5ECBD"
+                        title: "Ma\u00eetrise : Mcw Bridges"
+                        icon: {
+                                id: "mcwbridges:acacia_log_bridge_stair"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "B1C26A1CDD57474FA449632CDFC963EC"
+                                        type: "item"
+                                        item: {
+                                                id: "mcwbridges:acacia_log_bridge_stair"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "6DC83BD26DBC4F2398798E86BBABF82E"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "8EB0489D923D472BA169E640E71A2BD8"
+                        ]
+                },
+                {
+                        x: 20.0d
+                        y: 72.0d
+                        id: "127CBB77B80946098C63ABB7F9CDC976"
+                        title: "D\u00e9couverte : Mcw Doors"
+                        icon: {
+                                id: "mcwdoors:acacia_bamboo_door"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "B2CE49DEF2AD45D8B774625AF162D141"
+                                        type: "item"
+                                        item: {
+                                                id: "mcwdoors:acacia_bamboo_door"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "7EE3E101D0FE49C7A23C0E2F3F568792"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "96AE7F8DA6894512B1DDCAC6DDC5ECBD"
+                        ]
+                },
+                {
+                        x: 20.0d
+                        y: 74.0d
+                        id: "D8A152F50DE749FB8F3C0CDA7AA5EED6"
+                        title: "Progression : Mcw Doors"
+                        icon: {
+                                id: "mcwdoors:acacia_bark_glass_door"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "4D1A9D487BF340CB91F079B49BFF3875"
+                                        type: "item"
+                                        item: {
+                                                id: "mcwdoors:acacia_bark_glass_door"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "43DA013AC43C4316B2FAA39F64B52E0E"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "127CBB77B80946098C63ABB7F9CDC976"
+                        ]
+                },
+                {
+                        x: 20.0d
+                        y: 76.0d
+                        id: "CB826344502E4EFEAEE272A86EA993BA"
+                        title: "Ma\u00eetrise : Mcw Doors"
+                        icon: {
+                                id: "mcwdoors:acacia_barn_door"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "8885E88CCE46431C87918A0874657795"
+                                        type: "item"
+                                        item: {
+                                                id: "mcwdoors:acacia_barn_door"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "7617C0E7D30D40E4B2B70F7255E6B35C"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "D8A152F50DE749FB8F3C0CDA7AA5EED6"
+                        ]
+                },
+                {
+                        x: 25.0d
+                        y: 72.0d
+                        id: "FDEE905D0D464E54BC8B141D6BFFD3B9"
+                        title: "D\u00e9couverte : Mcw Fences"
+                        icon: {
+                                id: "mcwfences:acacia_curved_gate"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "2AF1E4DD889F45FE89CB52FBCAA00339"
+                                        type: "item"
+                                        item: {
+                                                id: "mcwfences:acacia_curved_gate"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "012F885B08F2469E87254D11471DB009"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "CB826344502E4EFEAEE272A86EA993BA"
+                        ]
+                },
+                {
+                        x: 25.0d
+                        y: 74.0d
+                        id: "D17147BFE8AF45DFB70D2DD4FA1D44E9"
+                        title: "Progression : Mcw Fences"
+                        icon: {
+                                id: "mcwfences:acacia_hedge"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "474A4B8E86C84644ABE904785A22827F"
+                                        type: "item"
+                                        item: {
+                                                id: "mcwfences:acacia_hedge"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "D0C9221B97A04C9B97AB897FD830636D"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "FDEE905D0D464E54BC8B141D6BFFD3B9"
+                        ]
+                },
+                {
+                        x: 25.0d
+                        y: 76.0d
+                        id: "98D423B06E164FE2A6D8C727D5913592"
+                        title: "Ma\u00eetrise : Mcw Fences"
+                        icon: {
+                                id: "mcwfences:acacia_highley_gate"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "676667373B0C4ED28BE31B0FE02DAEFE"
+                                        type: "item"
+                                        item: {
+                                                id: "mcwfences:acacia_highley_gate"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "82B82EE4B2A640318EBDB2100D04C60E"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "D17147BFE8AF45DFB70D2DD4FA1D44E9"
+                        ]
+                },
+                {
+                        x: 0.0d
+                        y: 80.0d
+                        id: "05450ECAC880430CB7090E6BA9A517F9"
+                        title: "D\u00e9couverte : Mcw Furniture"
+                        icon: {
+                                id: "mcwfurnitures:acacia_bookshelf"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "CD043FCBB03144C0BC204F4B13AEDD8C"
+                                        type: "item"
+                                        item: {
+                                                id: "mcwfurnitures:acacia_bookshelf"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "52215F29B6D045C3B61711921759927C"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "98D423B06E164FE2A6D8C727D5913592"
+                        ]
+                },
+                {
+                        x: 0.0d
+                        y: 82.0d
+                        id: "CB80E455E91B4790A8E756BE8254D679"
+                        title: "Progression : Mcw Furniture"
+                        icon: {
+                                id: "mcwfurnitures:acacia_bookshelf_cupboard"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "D0089FB918C34AB3B3F584F212F76FEE"
+                                        type: "item"
+                                        item: {
+                                                id: "mcwfurnitures:acacia_bookshelf_cupboard"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "E4FB0FD82720473EAF3220BFEC1CCADE"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "05450ECAC880430CB7090E6BA9A517F9"
+                        ]
+                },
+                {
+                        x: 0.0d
+                        y: 84.0d
+                        id: "DF587F6341114C66B3114005449F1AAF"
+                        title: "Ma\u00eetrise : Mcw Furniture"
+                        icon: {
+                                id: "mcwfurnitures:acacia_bookshelf_drawer"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "3A558609B966443AA700235D55D7F12B"
+                                        type: "item"
+                                        item: {
+                                                id: "mcwfurnitures:acacia_bookshelf_drawer"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "BF27820ADD9B46DCB7969F31E0E30161"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "CB80E455E91B4790A8E756BE8254D679"
+                        ]
+                },
+                {
+                        x: 5.0d
+                        y: 80.0d
+                        id: "EB706411F9FC4630AED6AC7B6CD988A2"
+                        title: "D\u00e9couverte : Mcw Holidays"
+                        icon: {
+                                id: "mcwholidays:bat_awake"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "2C4BCBC9878947E88FDBD22E018EE5ED"
+                                        type: "item"
+                                        item: {
+                                                id: "mcwholidays:bat_awake"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "DDB9AB9C09FF4B1182FEC33FD637B4DC"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "DF587F6341114C66B3114005449F1AAF"
+                        ]
+                },
+                {
+                        x: 5.0d
+                        y: 82.0d
+                        id: "11B343991D6A4712AAA80D5EA3AA5519"
+                        title: "Progression : Mcw Holidays"
+                        icon: {
+                                id: "mcwholidays:bat_doormat"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "557BFD1E3D454E6BB5C5DE5FE9114B83"
+                                        type: "item"
+                                        item: {
+                                                id: "mcwholidays:bat_doormat"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "9FC7603EC320432AA252A7AB44ED1B23"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "EB706411F9FC4630AED6AC7B6CD988A2"
+                        ]
+                },
+                {
+                        x: 5.0d
+                        y: 84.0d
+                        id: "D527067D63364023A84C7ECE0813FABB"
+                        title: "Ma\u00eetrise : Mcw Holidays"
+                        icon: {
+                                id: "mcwholidays:bat_sleeping"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "B04C1D37646C4B23B7A259F45E01D711"
+                                        type: "item"
+                                        item: {
+                                                id: "mcwholidays:bat_sleeping"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "16E7A24F460749E499F454BFE6D15045"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "11B343991D6A4712AAA80D5EA3AA5519"
+                        ]
+                },
+                {
+                        x: 10.0d
+                        y: 80.0d
+                        id: "5FE98FCF6DAE4B33B9AAEAEE499248D4"
+                        title: "D\u00e9couverte : Mcw Lights"
+                        icon: {
+                                id: "mcwlights:acacia_ceiling_fan_light"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "9FF15ED09A3F4B7A9528D232843EF6C0"
+                                        type: "item"
+                                        item: {
+                                                id: "mcwlights:acacia_ceiling_fan_light"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "E3BF8BC9453A489495EAED04327F0220"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "D527067D63364023A84C7ECE0813FABB"
+                        ]
+                },
+                {
+                        x: 10.0d
+                        y: 82.0d
+                        id: "6E9A4C7DCF8E4EDD967CB65F09828591"
+                        title: "Progression : Mcw Lights"
+                        icon: {
+                                id: "mcwlights:acacia_tiki_torch"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "2EC6362582864A7490CDAED87E576954"
+                                        type: "item"
+                                        item: {
+                                                id: "mcwlights:acacia_tiki_torch"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "F681F4E761DD43129347FF11FE4E62F0"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "5FE98FCF6DAE4B33B9AAEAEE499248D4"
+                        ]
+                },
+                {
+                        x: 10.0d
+                        y: 84.0d
+                        id: "F7187B6508824CBBBBC3FD747FB69755"
+                        title: "Ma\u00eetrise : Mcw Lights"
+                        icon: {
+                                id: "mcwlights:bamboo_tiki_torch"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "C64E66B76FE54CEDA2BAED83498C09AC"
+                                        type: "item"
+                                        item: {
+                                                id: "mcwlights:bamboo_tiki_torch"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "8C73122034FD436DB520144C0C900672"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "6E9A4C7DCF8E4EDD967CB65F09828591"
+                        ]
+                },
+                {
+                        x: 15.0d
+                        y: 80.0d
+                        id: "6DD65F1AED8B491E9D56933C6AB1CFF0"
+                        title: "D\u00e9couverte : Mcw Paths"
+                        icon: {
+                                id: "mcwpaths:acacia_planks_path"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "331739A8FC2F45808C762C0D9E0F953C"
+                                        type: "item"
+                                        item: {
+                                                id: "mcwpaths:acacia_planks_path"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "BC08A19E62674C4583CEF76E0D876826"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "F7187B6508824CBBBBC3FD747FB69755"
+                        ]
+                },
+                {
+                        x: 15.0d
+                        y: 82.0d
+                        id: "3C93704BE9C04BCA93AD7A564506357F"
+                        title: "Progression : Mcw Paths"
+                        icon: {
+                                id: "mcwpaths:andesite_basket_weave_paving"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "D2F3C2D2B91345C48CAAE29E1EE05731"
+                                        type: "item"
+                                        item: {
+                                                id: "mcwpaths:andesite_basket_weave_paving"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "E0FF1084DA6247B692CB807AEFE8C4E4"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "6DD65F1AED8B491E9D56933C6AB1CFF0"
+                        ]
+                },
+                {
+                        x: 15.0d
+                        y: 84.0d
+                        id: "C56CC93FA8FF43B59AB0BEA584856158"
+                        title: "Ma\u00eetrise : Mcw Paths"
+                        icon: {
+                                id: "mcwpaths:andesite_clover_paving"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "C42F2114C3AF415E870D4D4200F17CDC"
+                                        type: "item"
+                                        item: {
+                                                id: "mcwpaths:andesite_clover_paving"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "0390D42EDB8540E982A189830733FBE5"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "3C93704BE9C04BCA93AD7A564506357F"
+                        ]
+                },
+                {
+                        x: 20.0d
+                        y: 80.0d
+                        id: "CB94C690F43147328C60B02D1D5F0F6F"
+                        title: "D\u00e9couverte : Mcw Roofs"
+                        icon: {
+                                id: "mcwroofs:acacia_attic_roof"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "B421F2712AEA4D38B8E29E4D64229F73"
+                                        type: "item"
+                                        item: {
+                                                id: "mcwroofs:acacia_attic_roof"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "9E185442CFC34CCEAF8274C3FDD50AD3"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "C56CC93FA8FF43B59AB0BEA584856158"
+                        ]
+                },
+                {
+                        x: 20.0d
+                        y: 82.0d
+                        id: "199FF55245DC49649ADDA953E25416CA"
+                        title: "Progression : Mcw Roofs"
+                        icon: {
+                                id: "mcwroofs:acacia_lower_roof"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "E4997D187EF2489DB5843A77FC31CE69"
+                                        type: "item"
+                                        item: {
+                                                id: "mcwroofs:acacia_lower_roof"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "0718D5CF08F542A5B683EEBD16D05718"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "CB94C690F43147328C60B02D1D5F0F6F"
+                        ]
+                },
+                {
+                        x: 20.0d
+                        y: 84.0d
+                        id: "A8552A9ADE7D40D8903B445D7455B67E"
+                        title: "Ma\u00eetrise : Mcw Roofs"
+                        icon: {
+                                id: "mcwroofs:acacia_planks_attic_roof"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "1D3596CA49E247FBAAE3FF0A5701C04C"
+                                        type: "item"
+                                        item: {
+                                                id: "mcwroofs:acacia_planks_attic_roof"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "917EB7A4A54F410D95ED67D6FD2C136B"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "199FF55245DC49649ADDA953E25416CA"
+                        ]
+                },
+                {
+                        x: 25.0d
+                        y: 80.0d
+                        id: "0B2658616DCC4161A408204A765651DF"
+                        title: "D\u00e9couverte : Mcw Trapdoors"
+                        icon: {
+                                id: "mcwtrpdoors:acacia_bamboo_trapdoor"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "2E8B4B952E7C408185503F1EEAFDFD80"
+                                        type: "item"
+                                        item: {
+                                                id: "mcwtrpdoors:acacia_bamboo_trapdoor"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "34C2B014D63848C98F0F43492A0AF17D"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "A8552A9ADE7D40D8903B445D7455B67E"
+                        ]
+                },
+                {
+                        x: 25.0d
+                        y: 82.0d
+                        id: "36E2D6916AA8473CA0D26BE69354653E"
+                        title: "Progression : Mcw Trapdoors"
+                        icon: {
+                                id: "mcwtrpdoors:acacia_bark_trapdoor"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "D2040ACDDB43478294B2740A1C6E1062"
+                                        type: "item"
+                                        item: {
+                                                id: "mcwtrpdoors:acacia_bark_trapdoor"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "CF1DDED8F0864139A448B48DFFB8FEE4"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "0B2658616DCC4161A408204A765651DF"
+                        ]
+                },
+                {
+                        x: 25.0d
+                        y: 84.0d
+                        id: "F0EA5EAF6793483D9DEEEA03532E347D"
+                        title: "Ma\u00eetrise : Mcw Trapdoors"
+                        icon: {
+                                id: "mcwtrpdoors:acacia_barn_trapdoor"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "CF79EC17907941BFBB9D697F8D125533"
+                                        type: "item"
+                                        item: {
+                                                id: "mcwtrpdoors:acacia_barn_trapdoor"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "70BE370503E947E6A386CAF8616E7967"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "36E2D6916AA8473CA0D26BE69354653E"
+                        ]
+                },
+                {
+                        x: 0.0d
+                        y: 88.0d
+                        id: "FCD4CF710B1840929EF0FB78321B094D"
+                        title: "D\u00e9couverte : Mcw Windows"
+                        icon: {
+                                id: "mcwwindows:acacia_blinds"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "24DA14C770714712BCCE0A74AF519B46"
+                                        type: "item"
+                                        item: {
+                                                id: "mcwwindows:acacia_blinds"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "E8F50C0F11A3456E9946512B1936C712"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "F0EA5EAF6793483D9DEEEA03532E347D"
+                        ]
+                },
+                {
+                        x: 0.0d
+                        y: 90.0d
+                        id: "00487780CC33482C93BA03681ACFD095"
+                        title: "Progression : Mcw Windows"
+                        icon: {
+                                id: "mcwwindows:acacia_curtain_rod"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "0323B10C8FD34D71806E71F73F69FBBE"
+                                        type: "item"
+                                        item: {
+                                                id: "mcwwindows:acacia_curtain_rod"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "B3A65A989C724A2EA1154C92EDF14D8D"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "FCD4CF710B1840929EF0FB78321B094D"
+                        ]
+                },
+                {
+                        x: 0.0d
+                        y: 92.0d
+                        id: "2125B875C20644C08A6581CC64602AB5"
+                        title: "Ma\u00eetrise : Mcw Windows"
+                        icon: {
+                                id: "mcwwindows:acacia_four_window"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "93A33F71F5B04FF0B1C5124EDEFF5A04"
+                                        type: "item"
+                                        item: {
+                                                id: "mcwwindows:acacia_four_window"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "4D2B9B1B04B246EE8B540818764FCE21"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "00487780CC33482C93BA03681ACFD095"
+                        ]
+                },
+                {
+                        x: 5.0d
+                        y: 88.0d
+                        id: "8681F3349496468DBED7B5F31AAD72B1"
+                        title: "D\u00e9couverte : Mob Grinding Utils"
+                        icon: {
+                                id: "mob_grinding_utils:absorption_hopper"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "8C5BAC3DA9DA48389072B5F0EF428F6E"
+                                        type: "item"
+                                        item: {
+                                                id: "mob_grinding_utils:absorption_hopper"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "A5EA421B09274F899671F28E33B37B12"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "2125B875C20644C08A6581CC64602AB5"
+                        ]
+                },
+                {
+                        x: 5.0d
+                        y: 90.0d
+                        id: "944BD939022047798898EFB8DB0F866E"
+                        title: "Progression : Mob Grinding Utils"
+                        icon: {
+                                id: "mob_grinding_utils:absorption_upgrade"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "4D3D0517501F4ADFA8C78F1C0785CDB7"
+                                        type: "item"
+                                        item: {
+                                                id: "mob_grinding_utils:absorption_upgrade"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "72A47318165840B28A4B6B400EE3F413"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "8681F3349496468DBED7B5F31AAD72B1"
+                        ]
+                },
+                {
+                        x: 5.0d
+                        y: 92.0d
+                        id: "A66BB2EE6F314AFD88E7A93F0AE10B92"
+                        title: "Ma\u00eetrise : Mob Grinding Utils"
+                        icon: {
+                                id: "mob_grinding_utils:dark_oak_stone"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "6D21FEF9F6C94BA893D5689487985789"
+                                        type: "item"
+                                        item: {
+                                                id: "mob_grinding_utils:dark_oak_stone"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "46DA343D57A64A19A28517513EE2D451"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "944BD939022047798898EFB8DB0F866E"
+                        ]
+                },
+                {
+                        x: 10.0d
+                        y: 88.0d
+                        id: "68C4F93571944E32811936AF4F80D3F5"
+                        title: "D\u00e9couverte : Mobcatcher"
+                        icon: {
+                                id: "mobcatcher:net"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "C0B57BAA33214923BCF1337E1E9784D7"
+                                        type: "item"
+                                        item: {
+                                                id: "mobcatcher:net"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "BED9917B3BCC446EB32FD68C30277B73"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "A66BB2EE6F314AFD88E7A93F0AE10B92"
+                        ]
+                },
+                {
+                        x: 10.0d
+                        y: 90.0d
+                        id: "735AB97E363246B4A43D0E26960D1FE0"
+                        title: "Progression : Mobcatcher"
+                        icon: {
+                                id: "mobcatcher:net_launcher"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "B16527F7DBBA4B9CB4D35E92FD374F8D"
+                                        type: "item"
+                                        item: {
+                                                id: "mobcatcher:net_launcher"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "6C407F410C214480ACE08F51D0EFBC4F"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "68C4F93571944E32811936AF4F80D3F5"
+                        ]
+                },
+                {
+                        x: 15.0d
+                        y: 88.0d
+                        id: "B9AD1F99B0834E028683F8CFBF750C88"
+                        title: "D\u00e9couverte : Modernxlsurvival"
+                        icon: {
+                                id: "modernxl_ii:alabaster"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "AFB06CC2A54D4F66BD11E43268916839"
+                                        type: "item"
+                                        item: {
+                                                id: "modernxl_ii:alabaster"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "EDB55B7A9AF448788BC9F81880DE6B1C"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "735AB97E363246B4A43D0E26960D1FE0"
+                        ]
+                },
+                {
+                        x: 15.0d
+                        y: 90.0d
+                        id: "A3EBEC7FF7F94E75B376A8DB60470C87"
+                        title: "Progression : Modernxlsurvival"
+                        icon: {
+                                id: "modernxl_ii:alabaster_lamp_on"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "A430112D4410478B94AA1F6268B0E231"
+                                        type: "item"
+                                        item: {
+                                                id: "modernxl_ii:alabaster_lamp_on"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "00174E097ACE4028829A9363D7219876"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "B9AD1F99B0834E028683F8CFBF750C88"
+                        ]
+                },
+                {
+                        x: 15.0d
+                        y: 92.0d
+                        id: "922EB01FBF944B3BA29EE596C7357039"
+                        title: "Ma\u00eetrise : Modernxlsurvival"
+                        icon: {
+                                id: "modernxl_ii:alabaster_lampoff"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "6AE7D6B1F1A1428580E4B73A5C75A60D"
+                                        type: "item"
+                                        item: {
+                                                id: "modernxl_ii:alabaster_lampoff"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "C240A15460B84DC49152293BB2425300"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "A3EBEC7FF7F94E75B376A8DB60470C87"
+                        ]
+                },
+                {
+                        x: 20.0d
+                        y: 88.0d
+                        id: "8052A280F60543E290DA24AC39A4F058"
+                        title: "D\u00e9couverte : Mtr Forge"
+                        icon: {
+                                id: "mtr:airplane_node"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "49E9014F878A4842B3B3CA13067534F4"
+                                        type: "item"
+                                        item: {
+                                                id: "mtr:airplane_node"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "15F7342098114E81A360514AD7A7EF69"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "922EB01FBF944B3BA29EE596C7357039"
+                        ]
+                },
+                {
+                        x: 20.0d
+                        y: 90.0d
+                        id: "F7BF5E059C3E4E22BBDAA986D78FAD8F"
+                        title: "Progression : Mtr Forge"
+                        icon: {
+                                id: "mtr:apg_door"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "5A9393AEE6A7462D93A04FE12FAEF8EC"
+                                        type: "item"
+                                        item: {
+                                                id: "mtr:apg_door"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "8935AEB15B764E3FB8830BE6645F2E29"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "8052A280F60543E290DA24AC39A4F058"
+                        ]
+                },
+                {
+                        x: 20.0d
+                        y: 92.0d
+                        id: "9E9E87BD5F1647FEAFC9DCC3326FD0CB"
+                        title: "Ma\u00eetrise : Mtr Forge"
+                        icon: {
+                                id: "mtr:apg_glass"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "CE247021FC9F4D51B973AB9650AF51AA"
+                                        type: "item"
+                                        item: {
+                                                id: "mtr:apg_glass"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "60438A3AB7B540B5BCDE803D7FD3F9CC"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "F7BF5E059C3E4E22BBDAA986D78FAD8F"
+                        ]
+                },
+                {
+                        x: 25.0d
+                        y: 88.0d
+                        id: "49BB3245C5B5431EAEE30D74A4782ADD"
+                        title: "D\u00e9couverte : Naturescompass"
+                        icon: {
+                                id: "naturescompass:naturescompass"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "39A07A3E6F6C48B7B09586547CF80022"
+                                        type: "item"
+                                        item: {
+                                                id: "naturescompass:naturescompass"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "FB3264A6642A44F39CC9E9D5CFC58A12"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "9E9E87BD5F1647FEAFC9DCC3326FD0CB"
+                        ]
+                },
+                {
+                        x: 25.0d
+                        y: 90.0d
+                        id: "532419F2F1CC4EDA915E9589DDAF58B5"
+                        title: "Progression : Naturescompass"
+                        icon: {
+                                id: "naturescompass:naturescompass_00"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "3C428E11517E4238BFF0B58F8DB9DCB8"
+                                        type: "item"
+                                        item: {
+                                                id: "naturescompass:naturescompass_00"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "FC7E1E008CB1482D965309AA1EFD1EA9"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "49BB3245C5B5431EAEE30D74A4782ADD"
+                        ]
+                },
+                {
+                        x: 25.0d
+                        y: 92.0d
+                        id: "E06EFF1732094F67B0D8C4BEC52A3D58"
+                        title: "Ma\u00eetrise : Naturescompass"
+                        icon: {
+                                id: "naturescompass:naturescompass_01"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "B82065A199764A89B744297F8063FDD9"
+                                        type: "item"
+                                        item: {
+                                                id: "naturescompass:naturescompass_01"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "BCAF0407A60240FFAFEE19D38351920E"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "532419F2F1CC4EDA915E9589DDAF58B5"
+                        ]
+                },
+                {
+                        x: 0.0d
+                        y: 96.0d
+                        id: "A6D278FC54AF486EBCE5C50F6E4D12C3"
+                        title: "D\u00e9couverte : Nfm"
+                        icon: {
+                                id: "nfm:black_bar_stool"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "5699DE4DE4634C9EB3FD374096E14302"
+                                        type: "item"
+                                        item: {
+                                                id: "nfm:black_bar_stool"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "9CA39904707E4C1DBC7B388026FDF6E6"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "E06EFF1732094F67B0D8C4BEC52A3D58"
+                        ]
+                },
+                {
+                        x: 0.0d
+                        y: 98.0d
+                        id: "7791F05798F24293B2D28E2044C45324"
+                        title: "Progression : Nfm"
+                        icon: {
+                                id: "nfm:black_modern_bedside_cabinet"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "44409FF20CC3434EBC4B71EA0706F347"
+                                        type: "item"
+                                        item: {
+                                                id: "nfm:black_modern_bedside_cabinet"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "97451B47460D4F25A69BED28DFEA6F1C"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "A6D278FC54AF486EBCE5C50F6E4D12C3"
+                        ]
+                },
+                {
+                        x: 0.0d
+                        y: 100.0d
+                        id: "F31558CC0E2E43E19A334ACFF45B7209"
+                        title: "Ma\u00eetrise : Nfm"
+                        icon: {
+                                id: "nfm:black_modern_cabinet"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "27692035C56F422B963389C511360BEA"
+                                        type: "item"
+                                        item: {
+                                                id: "nfm:black_modern_cabinet"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "002B1452A67C4E888D2BE0A28433627D"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "7791F05798F24293B2D28E2044C45324"
+                        ]
+                },
+                {
+                        x: 5.0d
+                        y: 96.0d
+                        id: "E5ED1F7C08D4414EB79FEDB5F296C4AD"
+                        title: "D\u00e9couverte : Obscure Api"
+                        icon: {
+                                id: "obscure_api:astral_dust"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "39E95F39BABF4E28865EFDE0092E7C46"
+                                        type: "item"
+                                        item: {
+                                                id: "obscure_api:astral_dust"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "956257BDE53142118B5654D46A7F2828"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "F31558CC0E2E43E19A334ACFF45B7209"
+                        ]
+                },
+                {
+                        x: 5.0d
+                        y: 98.0d
+                        id: "2589123043C14986AEA94ACC87C04898"
+                        title: "Progression : Obscure Api"
+                        icon: {
+                                id: "obscure_api:obscure_book"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "AC2893B748674625ADCF2C1EF32A5A64"
+                                        type: "item"
+                                        item: {
+                                                id: "obscure_api:obscure_book"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "C1EB6AE8BB97447596282BE9EF65FD88"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "E5ED1F7C08D4414EB79FEDB5F296C4AD"
+                        ]
+                },
+                {
+                        x: 5.0d
+                        y: 100.0d
+                        id: "5A4E87AEB35741568C86910CD332336D"
+                        title: "Ma\u00eetrise : Obscure Api"
+                        icon: {
+                                id: "obscure_api:vial_of_knowledge"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "53FB9D248EE141AD987C28FA488CE36C"
+                                        type: "item"
+                                        item: {
+                                                id: "obscure_api:vial_of_knowledge"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "583A655ED26D4277B9D770875118562C"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "2589123043C14986AEA94ACC87C04898"
+                        ]
+                },
+                {
+                        x: 10.0d
+                        y: 96.0d
+                        id: "A2EAFF14E9B64B4A945EFE25E20564E1"
+                        title: "D\u00e9couverte : Oceanworld"
+                        icon: {
+                                id: "oceanworld:black_brick"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "0C9EF7EF571B4E4FB76D1AE1BA700C1E"
+                                        type: "item"
+                                        item: {
+                                                id: "oceanworld:black_brick"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "A3A49B44A39C41CD8E5ED7355D38A3C1"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "5A4E87AEB35741568C86910CD332336D"
+                        ]
+                },
+                {
+                        x: 10.0d
+                        y: 98.0d
+                        id: "EE4E00592A5A456FAC0C26ED056B50EF"
+                        title: "Progression : Oceanworld"
+                        icon: {
+                                id: "oceanworld:black_brick_slab"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "D1E63355F8C94B11893FBDD69185C395"
+                                        type: "item"
+                                        item: {
+                                                id: "oceanworld:black_brick_slab"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "07B312A1F3E04B668E59DB251214A80C"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "A2EAFF14E9B64B4A945EFE25E20564E1"
+                        ]
+                },
+                {
+                        x: 10.0d
+                        y: 100.0d
+                        id: "CCE2FDB5E1EB4B45895C87BB333E2D95"
+                        title: "Ma\u00eetrise : Oceanworld"
+                        icon: {
+                                id: "oceanworld:black_brick_stairs"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "CBB716E81B3C426A98FB1C8871DB24A4"
+                                        type: "item"
+                                        item: {
+                                                id: "oceanworld:black_brick_stairs"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "F40A705F5D2248369D2C0DE86D8F7627"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "EE4E00592A5A456FAC0C26ED056B50EF"
+                        ]
+                },
+                {
+                        x: 15.0d
+                        y: 96.0d
+                        id: "34378B0AB78B49658FE30B3BB74CE866"
+                        title: "D\u00e9couverte : Orelibrary"
+                        icon: {
+                                id: "orelibrary:copper_ingot"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "7E67BDD9C2B54E6BA2D1297C766E0D89"
+                                        type: "item"
+                                        item: {
+                                                id: "orelibrary:copper_ingot"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "BD43C6CB70744095A925CC29B044B36B"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "CCE2FDB5E1EB4B45895C87BB333E2D95"
+                        ]
+                },
+                {
+                        x: 15.0d
+                        y: 98.0d
+                        id: "298BAFE8E3AF41E088814A64390DBADC"
+                        title: "Progression : Orelibrary"
+                        icon: {
+                                id: "orelibrary:copper_nugget"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "F5C1AD863BC9484DAFE13C75DECAF0BA"
+                                        type: "item"
+                                        item: {
+                                                id: "orelibrary:copper_nugget"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "7E38DF342AED4BAF967340C14EAFECE4"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "34378B0AB78B49658FE30B3BB74CE866"
+                        ]
+                },
+                {
+                        x: 15.0d
+                        y: 100.0d
+                        id: "C1B7C5C0C4B44215A6E9ACCE965D5A3D"
+                        title: "Ma\u00eetrise : Orelibrary"
+                        icon: {
+                                id: "orelibrary:copper_ore"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "27F9F2785444447D8FBBA9B3323CB87D"
+                                        type: "item"
+                                        item: {
+                                                id: "orelibrary:copper_ore"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "B6DBF526094B483CB0433D59D603383E"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "298BAFE8E3AF41E088814A64390DBADC"
+                        ]
+                },
+                {
+                        x: 20.0d
+                        y: 96.0d
+                        id: "29779E155DEA4E32A5AFC7F238D78D7D"
+                        title: "D\u00e9couverte : Patchouli"
+                        icon: {
+                                id: "patchouli:book_blue"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "17C514C19A02466DB4920CE99679FEE8"
+                                        type: "item"
+                                        item: {
+                                                id: "patchouli:book_blue"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "8B67476EBC484C84BF58A00E38194CD8"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "C1B7C5C0C4B44215A6E9ACCE965D5A3D"
+                        ]
+                },
+                {
+                        x: 20.0d
+                        y: 98.0d
+                        id: "9BE6BC33ACEA4AD99EABBB4411561D9C"
+                        title: "Progression : Patchouli"
+                        icon: {
+                                id: "patchouli:book_brown"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "4047089725E542CEA218883363F78F29"
+                                        type: "item"
+                                        item: {
+                                                id: "patchouli:book_brown"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "0CFCEC9443074459994B9EDCE5EE48AB"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "29779E155DEA4E32A5AFC7F238D78D7D"
+                        ]
+                },
+                {
+                        x: 20.0d
+                        y: 100.0d
+                        id: "29F06E7427C24B4D8754CFC1D3BA2C0E"
+                        title: "Ma\u00eetrise : Patchouli"
+                        icon: {
+                                id: "patchouli:book_completion"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "0A33D7811386410D9AFD0E7FD34026CB"
+                                        type: "item"
+                                        item: {
+                                                id: "patchouli:book_completion"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "409F9DCFBEFF44F6A4CB17D89B558E78"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "9BE6BC33ACEA4AD99EABBB4411561D9C"
+                        ]
+                },
+                {
+                        x: 25.0d
+                        y: 96.0d
+                        id: "A929D0FA4F154056B902E1E5B50EDA6D"
+                        title: "D\u00e9couverte : Quark"
+                        icon: {
+                                id: "quark:abacus"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "A81E9692CB624AC1972DC985417EB686"
+                                        type: "item"
+                                        item: {
+                                                id: "quark:abacus"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "45D82C5725884144A2E83FE1B6D01CAA"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "29F06E7427C24B4D8754CFC1D3BA2C0E"
+                        ]
+                },
+                {
+                        x: 25.0d
+                        y: 98.0d
+                        id: "2E3C7FE102124916BFC8C18630A1A1C5"
+                        title: "Progression : Quark"
+                        icon: {
+                                id: "quark:abacus_0"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "74F37EB9E50E470997F61D4261A5F0CF"
+                                        type: "item"
+                                        item: {
+                                                id: "quark:abacus_0"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "F03726DFF45B4FA38BADEAAFB2671219"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "A929D0FA4F154056B902E1E5B50EDA6D"
+                        ]
+                },
+                {
+                        x: 25.0d
+                        y: 100.0d
+                        id: "A5B9B9F738854E938177BFA45E6FFABC"
+                        title: "Ma\u00eetrise : Quark"
+                        icon: {
+                                id: "quark:abacus_1"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "CB25DDEDDE2C465FAD471709AA3460A6"
+                                        type: "item"
+                                        item: {
+                                                id: "quark:abacus_1"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "B1F50E1ED17749C79AE739E9FA6A3B24"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "2E3C7FE102124916BFC8C18630A1A1C5"
+                        ]
+                },
+                {
+                        x: 0.0d
+                        y: 104.0d
+                        id: "24D18F26951042DBB3E71D631BCE0C70"
+                        title: "D\u00e9couverte : Randomium"
+                        icon: {
+                                id: "randomium:any_item"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "E3A9E2AA982C414695C37AB88A1CB602"
+                                        type: "item"
+                                        item: {
+                                                id: "randomium:any_item"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "9D4B150C7EB64A0988C9D5C170AF2672"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "A5B9B9F738854E938177BFA45E6FFABC"
+                        ]
+                },
+                {
+                        x: 0.0d
+                        y: 106.0d
+                        id: "DCD81864CA4B4D5F9C4F6E6F66F77B4D"
+                        title: "Progression : Randomium"
+                        icon: {
+                                id: "randomium:randomium"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "861FB9E4F3BA421EBDC4ADDCB5006228"
+                                        type: "item"
+                                        item: {
+                                                id: "randomium:randomium"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "E73B095A9A4B4275B326962D4A5A630E"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "24D18F26951042DBB3E71D631BCE0C70"
+                        ]
+                },
+                {
+                        x: 0.0d
+                        y: 108.0d
+                        id: "648DF95F67544E72B0842097FD21B58B"
+                        title: "Ma\u00eetrise : Randomium"
+                        icon: {
+                                id: "randomium:randomium_ore"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "A3CC2D5E2DEC44ECAE5891F4A556A7BE"
+                                        type: "item"
+                                        item: {
+                                                id: "randomium:randomium_ore"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "DBB8CAC7442F4C6DAB1113F5313F0153"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "DCD81864CA4B4D5F9C4F6E6F66F77B4D"
+                        ]
+                },
+                {
+                        x: 5.0d
+                        y: 104.0d
+                        id: "0A12A9CC5E4140EB8ECB56D90C69B01D"
+                        title: "D\u00e9couverte : Refinedstorage"
+                        icon: {
+                                id: "refinedstorage:1024k_fluid_storage_block"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "112CC9814B2547C982C881E7DA6C9AB8"
+                                        type: "item"
+                                        item: {
+                                                id: "refinedstorage:1024k_fluid_storage_block"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "617CDFB97C7F44E4B063C59BF9FF9273"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "648DF95F67544E72B0842097FD21B58B"
+                        ]
+                },
+                {
+                        x: 5.0d
+                        y: 106.0d
+                        id: "93CB95C7B3514E6086E55638BBD4CC11"
+                        title: "Progression : Refinedstorage"
+                        icon: {
+                                id: "refinedstorage:1024k_fluid_storage_disk"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "052D1B38FC5C42A5AD65CF4B4FB0AC17"
+                                        type: "item"
+                                        item: {
+                                                id: "refinedstorage:1024k_fluid_storage_disk"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "6155BC191ADC4C999DE4E2C1911C260E"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "0A12A9CC5E4140EB8ECB56D90C69B01D"
+                        ]
+                },
+                {
+                        x: 5.0d
+                        y: 108.0d
+                        id: "43A66657785F435498CFB7F6918E3FB8"
+                        title: "Ma\u00eetrise : Refinedstorage"
+                        icon: {
+                                id: "refinedstorage:1024k_fluid_storage_part"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "8DBDAD497EB44A68A6D964CB90F57041"
+                                        type: "item"
+                                        item: {
+                                                id: "refinedstorage:1024k_fluid_storage_part"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "BDF6896C3C3D4BA1B24D8FEF2E24ED81"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "93CB95C7B3514E6086E55638BBD4CC11"
+                        ]
+                },
+                {
+                        x: 10.0d
+                        y: 104.0d
+                        id: "212B609E12284D0FB6467BF5D902069E"
+                        title: "D\u00e9couverte : Refinedstorageaddons"
+                        icon: {
+                                id: "refinedstorageaddons:creative_wireless_crafting_grid"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "F0D53583E1F648748882B414E9B37DE1"
+                                        type: "item"
+                                        item: {
+                                                id: "refinedstorageaddons:creative_wireless_crafting_grid"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "71E29C01B94C4A43983F9A5269ECB0FF"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "43A66657785F435498CFB7F6918E3FB8"
+                        ]
+                },
+                {
+                        x: 10.0d
+                        y: 106.0d
+                        id: "FA5E86791D964F42B03A13AFB0812939"
+                        title: "Progression : Refinedstorageaddons"
+                        icon: {
+                                id: "refinedstorageaddons:wireless_crafting_grid"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "95323552CFB543DABC5E8593211CC2E9"
+                                        type: "item"
+                                        item: {
+                                                id: "refinedstorageaddons:wireless_crafting_grid"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "CD492606EA1A43909C28245FBEE8AE31"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "212B609E12284D0FB6467BF5D902069E"
+                        ]
+                },
+                {
+                        x: 10.0d
+                        y: 108.0d
+                        id: "1529E278A3F848DCA2FFA5D1B717108C"
+                        title: "Ma\u00eetrise : Refinedstorageaddons"
+                        icon: {
+                                id: "refinedstorageaddons:wireless_crafting_grid_connected"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "6484F01DAF86490688B8541EF4E2437C"
+                                        type: "item"
+                                        item: {
+                                                id: "refinedstorageaddons:wireless_crafting_grid_connected"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "321AFFDF32EE4086AD2F84B140EBAA55"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "FA5E86791D964F42B03A13AFB0812939"
+                        ]
+                },
+                {
+                        x: 15.0d
+                        y: 104.0d
+                        id: "5682957C9C834E4587E354B3424C3FF9"
+                        title: "D\u00e9couverte : Roadstuff"
+                        icon: {
+                                id: "roadstuff:asphalt"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "73C406A88C53495E9C37DC1C46545BBF"
+                                        type: "item"
+                                        item: {
+                                                id: "roadstuff:asphalt"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "B1258447DB1046B494D2A2D83017DDE0"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "1529E278A3F848DCA2FFA5D1B717108C"
+                        ]
+                },
+                {
+                        x: 15.0d
+                        y: 106.0d
+                        id: "62354FB525C64164A3711BE149DF6F84"
+                        title: "Progression : Roadstuff"
+                        icon: {
+                                id: "roadstuff:asphalt_pressure_plate"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "5E260EA04E4A425699319D3D30B7B41E"
+                                        type: "item"
+                                        item: {
+                                                id: "roadstuff:asphalt_pressure_plate"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "750FA7418C7342528DD4BE06B19CD43A"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "5682957C9C834E4587E354B3424C3FF9"
+                        ]
+                },
+                {
+                        x: 15.0d
+                        y: 108.0d
+                        id: "A17F26C5B3E847ED93F70D6662B08D9D"
+                        title: "Ma\u00eetrise : Roadstuff"
+                        icon: {
+                                id: "roadstuff:asphalt_slab"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "5DCC25873D9C4608BB6D29864CF82A92"
+                                        type: "item"
+                                        item: {
+                                                id: "roadstuff:asphalt_slab"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "3CDF679E29BF481A884462F3443C8779"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "62354FB525C64164A3711BE149DF6F84"
+                        ]
+                },
+                {
+                        x: 20.0d
+                        y: 104.0d
+                        id: "CEAE4BF6C9474B0FA4DFA9D8AD056462"
+                        title: "D\u00e9couverte : Rsgauges"
+                        icon: {
+                                id: "rsgauges:arrow_target"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "EC4DD97D4CE346948A6512AD0098955D"
+                                        type: "item"
+                                        item: {
+                                                id: "rsgauges:arrow_target"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "19EC38419EDE43528B5C7D13C17A1A50"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "A17F26C5B3E847ED93F70D6662B08D9D"
+                        ]
+                },
+                {
+                        x: 20.0d
+                        y: 106.0d
+                        id: "6A1F6D0D576B43489D4B37368C7C1AF8"
+                        title: "Progression : Rsgauges"
+                        icon: {
+                                id: "rsgauges:door_sensor_switch"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "C71C97198227456F83AA82974EF728E3"
+                                        type: "item"
+                                        item: {
+                                                id: "rsgauges:door_sensor_switch"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "EC40E89E440C4111BC78B3F4150B5F91"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "CEAE4BF6C9474B0FA4DFA9D8AD056462"
+                        ]
+                },
+                {
+                        x: 20.0d
+                        y: 108.0d
+                        id: "B6C92A0505FF41829D262841B3EB6388"
+                        title: "Ma\u00eetrise : Rsgauges"
+                        icon: {
+                                id: "rsgauges:elevator_button"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "944705AD14994930BC9AAF201FBC39FF"
+                                        type: "item"
+                                        item: {
+                                                id: "rsgauges:elevator_button"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "3C8261E3E49E4831BD34620ECA787137"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "6A1F6D0D576B43489D4B37368C7C1AF8"
+                        ]
+                },
+                {
+                        x: 25.0d
+                        y: 104.0d
+                        id: "6750965C7A7D4AD6B60C670ADE55F988"
+                        title: "D\u00e9couverte : Signtastic"
+                        icon: {
+                                id: "signtastic:block_sign"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "2EA526BCC67D4E3AA72732B971294EAA"
+                                        type: "item"
+                                        item: {
+                                                id: "signtastic:block_sign"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "4623A2B0B5714C7DA8BC26E43D4C4E7E"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "B6C92A0505FF41829D262841B3EB6388"
+                        ]
+                },
+                {
+                        x: 25.0d
+                        y: 106.0d
+                        id: "0D2F62DA800040E0B7BA686378B12911"
+                        title: "Progression : Signtastic"
+                        icon: {
+                                id: "signtastic:sign_configurator"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "5CC9F84EFEA94E78AB36B87AC10182D6"
+                                        type: "item"
+                                        item: {
+                                                id: "signtastic:sign_configurator"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "45AD770CD141470B85D498F8ED0158AC"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "6750965C7A7D4AD6B60C670ADE55F988"
+                        ]
+                },
+                {
+                        x: 25.0d
+                        y: 108.0d
+                        id: "0753CDA734BD400A94C7C2E15F15A8C2"
+                        title: "Ma\u00eetrise : Signtastic"
+                        icon: {
+                                id: "signtastic:slab_sign"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "1E7149E6D87D4BBFAF374E2AAA581A95"
+                                        type: "item"
+                                        item: {
+                                                id: "signtastic:slab_sign"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "AA5B8EE77B6C4C75A205AC3B4D2C4644"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "0D2F62DA800040E0B7BA686378B12911"
+                        ]
+                },
+                {
+                        x: 0.0d
+                        y: 112.0d
+                        id: "230C28509DF34EAB99767A4403145F96"
+                        title: "D\u00e9couverte : Simplemagnets"
+                        icon: {
+                                id: "simplemagnets:advanced_demagnetization_coil"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "E74EFCBF94D44B9A9FBE0A5646A9E131"
+                                        type: "item"
+                                        item: {
+                                                id: "simplemagnets:advanced_demagnetization_coil"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "35D9E6F6DD374233AA2B84EB7BEF19E6"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "0753CDA734BD400A94C7C2E15F15A8C2"
+                        ]
+                },
+                {
+                        x: 0.0d
+                        y: 114.0d
+                        id: "8078B8D4E7294C679C0237CF68DA492E"
+                        title: "Progression : Simplemagnets"
+                        icon: {
+                                id: "simplemagnets:advancedmagnet"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "280A7ACF20CA4EEABF7EB90AEB5681D9"
+                                        type: "item"
+                                        item: {
+                                                id: "simplemagnets:advancedmagnet"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "F94FA4AB4AFF4F7BB2D935774670D677"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "230C28509DF34EAB99767A4403145F96"
+                        ]
+                },
+                {
+                        x: 0.0d
+                        y: 116.0d
+                        id: "1699F1F7F0594881988D6B18696E23CB"
+                        title: "Ma\u00eetrise : Simplemagnets"
+                        icon: {
+                                id: "simplemagnets:basic_demagnetization_coil"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "5536CBCC424F43C98E5EEE1765230BFE"
+                                        type: "item"
+                                        item: {
+                                                id: "simplemagnets:basic_demagnetization_coil"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "EAB9C3BCD23D4A6CB251CEF3CA4E4431"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "8078B8D4E7294C679C0237CF68DA492E"
+                        ]
+                },
+                {
+                        x: 5.0d
+                        y: 112.0d
+                        id: "9F1830C67FA948D6BC97DF025E1D0DC8"
+                        title: "D\u00e9couverte : Simplestoragenetwork"
+                        icon: {
+                                id: "storagenetwork:builder_remote"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "7239C2C53AC54E4AA8180E7BBA5907A4"
+                                        type: "item"
+                                        item: {
+                                                id: "storagenetwork:builder_remote"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "7FAA6F33CB2D421297B1C7AE6D6BEE86"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "1699F1F7F0594881988D6B18696E23CB"
+                        ]
+                },
+                {
+                        x: 5.0d
+                        y: 114.0d
+                        id: "4CC873A960E34615B6E430C56299ACA3"
+                        title: "Progression : Simplestoragenetwork"
+                        icon: {
+                                id: "storagenetwork:collector"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "7785B88D4FBC4A8FB686D15B13C631AB"
+                                        type: "item"
+                                        item: {
+                                                id: "storagenetwork:collector"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "4C7A4543273A4FD593ACCA1F433EE129"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "9F1830C67FA948D6BC97DF025E1D0DC8"
+                        ]
+                },
+                {
+                        x: 5.0d
+                        y: 116.0d
+                        id: "E659124054624A88A0A528A1EF7643BA"
+                        title: "Ma\u00eetrise : Simplestoragenetwork"
+                        icon: {
+                                id: "storagenetwork:collector_remote"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "D134E0135E3C42D2B35B2DD2D0975B00"
+                                        type: "item"
+                                        item: {
+                                                id: "storagenetwork:collector_remote"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "284CA2EFFB9940729B28C17ECC1D92E7"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "4CC873A960E34615B6E430C56299ACA3"
+                        ]
+                },
+                {
+                        x: 10.0d
+                        y: 112.0d
+                        id: "F29EEF01D3FD440B8FC09F7BB85BE11E"
+                        title: "D\u00e9couverte : Simply Loot Bags"
+                        icon: {
+                                id: "simply_loot_bags:common_loot_bag"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "E91278406FEE4AE891E889D1AAA8B550"
+                                        type: "item"
+                                        item: {
+                                                id: "simply_loot_bags:common_loot_bag"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "7BB15072B4FC4BF6BD3140CFCF9CBD84"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "E659124054624A88A0A528A1EF7643BA"
+                        ]
+                },
+                {
+                        x: 10.0d
+                        y: 114.0d
+                        id: "B9DC4E42BFA04B9CA62E570F7B9C6CDA"
+                        title: "Progression : Simply Loot Bags"
+                        icon: {
+                                id: "simply_loot_bags:diamond_loot_bag"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "1D5C84BF610C4D138F925AADFF32AC3D"
+                                        type: "item"
+                                        item: {
+                                                id: "simply_loot_bags:diamond_loot_bag"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "0B3E480D1C82478C927FC3CF18FCFF4E"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "F29EEF01D3FD440B8FC09F7BB85BE11E"
+                        ]
+                },
+                {
+                        x: 10.0d
+                        y: 116.0d
+                        id: "75432BCE637C4A039E9395E850B6B4DD"
+                        title: "Ma\u00eetrise : Simply Loot Bags"
+                        icon: {
+                                id: "simply_loot_bags:diamond_nugget"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "77996DFDBA98457CBD57FE5C6FC9358A"
+                                        type: "item"
+                                        item: {
+                                                id: "simply_loot_bags:diamond_nugget"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "FD98AD5E4B7840F7BD640FDDFAC1C85E"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "B9DC4E42BFA04B9CA62E570F7B9C6CDA"
+                        ]
+                },
+                {
+                        x: 15.0d
+                        y: 112.0d
+                        id: "2A5A425CB85A4AAC8CF7A7BB7D3F5F45"
+                        title: "D\u00e9couverte : Simplylight"
+                        icon: {
+                                id: "simplylight:edge_light"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "8CC109D2A01543F480B3CDA25983D6A7"
+                                        type: "item"
+                                        item: {
+                                                id: "simplylight:edge_light"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "0160A29014074BBEA94E517260302121"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "75432BCE637C4A039E9395E850B6B4DD"
+                        ]
+                },
+                {
+                        x: 15.0d
+                        y: 114.0d
+                        id: "230F44565EEB45A9940FA300E9DE0923"
+                        title: "Progression : Simplylight"
+                        icon: {
+                                id: "simplylight:edge_light_top"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "E1B8FC184F104F758DA1136091C51568"
+                                        type: "item"
+                                        item: {
+                                                id: "simplylight:edge_light_top"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "9C8675E19F3841428EE75F5463C86E57"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "2A5A425CB85A4AAC8CF7A7BB7D3F5F45"
+                        ]
+                },
+                {
+                        x: 15.0d
+                        y: 116.0d
+                        id: "7B099EB654A24579A2AAF450D66740BD"
+                        title: "Ma\u00eetrise : Simplylight"
+                        icon: {
+                                id: "simplylight:illuminant_black_block"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "26C3A39AEB28477BAA3BFA78632BA919"
+                                        type: "item"
+                                        item: {
+                                                id: "simplylight:illuminant_black_block"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "1E84FBAC821F4B84985F7CFCC92544EC"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "230F44565EEB45A9940FA300E9DE0923"
+                        ]
+                },
+                {
+                        x: 20.0d
+                        y: 112.0d
+                        id: "695DE741C2604A68A70689CAF04493B3"
+                        title: "D\u00e9couverte : Solargeneration"
+                        icon: {
+                                id: "solargeneration:lapis_shard"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "3B45FE76C6D34C73834637F07DE6D23E"
+                                        type: "item"
+                                        item: {
+                                                id: "solargeneration:lapis_shard"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "6699168A3312454898F9E46977B93163"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "7B099EB654A24579A2AAF450D66740BD"
+                        ]
+                },
+                {
+                        x: 20.0d
+                        y: 114.0d
+                        id: "39E22E73BD6F4BC1934C300EAE13C45D"
+                        title: "Progression : Solargeneration"
+                        icon: {
+                                id: "solargeneration:photovoltaic_cell"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "1F8FB91C75F2479CA6C3FD42BFC69849"
+                                        type: "item"
+                                        item: {
+                                                id: "solargeneration:photovoltaic_cell"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "070E8948252E41DEB48B016B8DF1C474"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "695DE741C2604A68A70689CAF04493B3"
+                        ]
+                },
+                {
+                        x: 20.0d
+                        y: 116.0d
+                        id: "24C9A51ACAD1454EBB443900A60B6487"
+                        title: "Ma\u00eetrise : Solargeneration"
+                        icon: {
+                                id: "solargeneration:solar_core_advanced"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "D5AFD0459A35469DB2BC8F8A8E94B3D6"
+                                        type: "item"
+                                        item: {
+                                                id: "solargeneration:solar_core_advanced"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "47F2F67D789C4FDA8471EDF8A8BD1D27"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "39E22E73BD6F4BC1934C300EAE13C45D"
+                        ]
+                },
+                {
+                        x: 25.0d
+                        y: 112.0d
+                        id: "B56DACF87072406A8831289582DB015C"
+                        title: "D\u00e9couverte : Storagedrawers"
+                        icon: {
+                                id: "storagedrawers:acacia_full_drawers_1"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "8602E03658554914900A26A990D6DF09"
+                                        type: "item"
+                                        item: {
+                                                id: "storagedrawers:acacia_full_drawers_1"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "464926F7EE71444788404AF0D6D59E25"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "24C9A51ACAD1454EBB443900A60B6487"
+                        ]
+                },
+                {
+                        x: 25.0d
+                        y: 114.0d
+                        id: "C0FDC162C1E24086A3F3266AEF6C2864"
+                        title: "Progression : Storagedrawers"
+                        icon: {
+                                id: "storagedrawers:acacia_full_drawers_2"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "8D229FE89ADD440C80DBAD49AFCBFF48"
+                                        type: "item"
+                                        item: {
+                                                id: "storagedrawers:acacia_full_drawers_2"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "56738989FC8A441DB9D30FCE06A2A3EA"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "B56DACF87072406A8831289582DB015C"
+                        ]
+                },
+                {
+                        x: 25.0d
+                        y: 116.0d
+                        id: "2698FB2D6FCA4CA6A06F24032D131DDA"
+                        title: "Ma\u00eetrise : Storagedrawers"
+                        icon: {
+                                id: "storagedrawers:acacia_full_drawers_4"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "94782FBB0C6341F2825BDD303C86FF3C"
+                                        type: "item"
+                                        item: {
+                                                id: "storagedrawers:acacia_full_drawers_4"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "2C8E540A59DF441DA23CFE15C78CE4FA"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "C0FDC162C1E24086A3F3266AEF6C2864"
+                        ]
+                },
+                {
+                        x: 0.0d
+                        y: 120.0d
+                        id: "854DEEA9389C4314AB98B23F1E8521EB"
+                        title: "D\u00e9couverte : Structure Gel"
+                        icon: {
+                                id: "structure_gel:blue_gel"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "B9317076630B4EDE86CE18FF6F13A172"
+                                        type: "item"
+                                        item: {
+                                                id: "structure_gel:blue_gel"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "D3B15E8CE1C744E8A084F2698A0ADAC2"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "2698FB2D6FCA4CA6A06F24032D131DDA"
+                        ]
+                },
+                {
+                        x: 0.0d
+                        y: 122.0d
+                        id: "A61F1544ED874F8FB85D75495026ACCC"
+                        title: "Progression : Structure Gel"
+                        icon: {
+                                id: "structure_gel:building_tool"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "2EA3B1623EC6405CBFDB823C58E7128C"
+                                        type: "item"
+                                        item: {
+                                                id: "structure_gel:building_tool"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "793BBCD1699243B48ADC8544B104870F"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "854DEEA9389C4314AB98B23F1E8521EB"
+                        ]
+                },
+                {
+                        x: 0.0d
+                        y: 124.0d
+                        id: "47E904C9D20146CBA8949F178CFE11F7"
+                        title: "Ma\u00eetrise : Structure Gel"
+                        icon: {
+                                id: "structure_gel:building_tool_clear"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "EE5D792246CD42779EBF31AB3BEA9C39"
+                                        type: "item"
+                                        item: {
+                                                id: "structure_gel:building_tool_clear"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "369EC78CCB7E41A897E8E0E4FD1C420B"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "A61F1544ED874F8FB85D75495026ACCC"
+                        ]
+                },
+                {
+                        x: 5.0d
+                        y: 120.0d
+                        id: "B32326B3670C4985AB153ED64942C260"
+                        title: "D\u00e9couverte : Tacz"
+                        icon: {
+                                id: "tacz:all_type_creative_ammo_box"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "85BE2F7E1FA4417BBAC882F7B55C6621"
+                                        type: "item"
+                                        item: {
+                                                id: "tacz:all_type_creative_ammo_box"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "09BF71FBF7AD49E8834B7D1E56AEA2F1"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "47E904C9D20146CBA8949F178CFE11F7"
+                        ]
+                },
+                {
+                        x: 5.0d
+                        y: 122.0d
+                        id: "B40E3C3B8AF443EE9D144387D784C866"
+                        title: "Progression : Tacz"
+                        icon: {
+                                id: "tacz:ammo"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "4AD44ED73106458BB28EE0D61736AF75"
+                                        type: "item"
+                                        item: {
+                                                id: "tacz:ammo"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "0C77E30C4BDD402FBE9CA7C8BE4E7611"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "B32326B3670C4985AB153ED64942C260"
+                        ]
+                },
+                {
+                        x: 5.0d
+                        y: 124.0d
+                        id: "7D31A94C05954AF3B173DD0730788653"
+                        title: "Ma\u00eetrise : Tacz"
+                        icon: {
+                                id: "tacz:ammo_box"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "4445021AEBA146B6BB12573922838334"
+                                        type: "item"
+                                        item: {
+                                                id: "tacz:ammo_box"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "3B6A2C310C984D5DB03D9AB940119C84"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "B40E3C3B8AF443EE9D144387D784C866"
+                        ]
+                },
+                {
+                        x: 10.0d
+                        y: 120.0d
+                        id: "FDC973F7A44E444DBE4DD52C22DACC94"
+                        title: "D\u00e9couverte : Torchmaster"
+                        icon: {
+                                id: "torchmaster:dreadlamp"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "8A60B5D811E14AFABA6D28475FCF3AD6"
+                                        type: "item"
+                                        item: {
+                                                id: "torchmaster:dreadlamp"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "1942587175EB4E319812A50DC0F251FA"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "7D31A94C05954AF3B173DD0730788653"
+                        ]
+                },
+                {
+                        x: 10.0d
+                        y: 122.0d
+                        id: "2DFE9890B902477590E1E2CB09765E6F"
+                        title: "Progression : Torchmaster"
+                        icon: {
+                                id: "torchmaster:feral_flare_lantern"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "D305331BDD484354BFA25DD4A66B942D"
+                                        type: "item"
+                                        item: {
+                                                id: "torchmaster:feral_flare_lantern"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "95F0CFAD03EC4C8E949FADB2A7BFC740"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "FDC973F7A44E444DBE4DD52C22DACC94"
+                        ]
+                },
+                {
+                        x: 10.0d
+                        y: 124.0d
+                        id: "0F0377A205004F6990D8922178323D2E"
+                        title: "Ma\u00eetrise : Torchmaster"
+                        icon: {
+                                id: "torchmaster:frozen_pearl"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "04531EDDFBB343DB8E825AE4E902D77E"
+                                        type: "item"
+                                        item: {
+                                                id: "torchmaster:frozen_pearl"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "751F838660A94D4688EC9397CA17F704"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "2DFE9890B902477590E1E2CB09765E6F"
+                        ]
+                },
+                {
+                        x: 15.0d
+                        y: 120.0d
+                        id: "00B9D02B9FCA4010A524FC6C8252ECCA"
+                        title: "D\u00e9couverte : Waterframes Forge"
+                        icon: {
+                                id: "waterframes:big_tv"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "D937D11B5F7F47C4A7135DE9B905DEBF"
+                                        type: "item"
+                                        item: {
+                                                id: "waterframes:big_tv"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "E75A1C24C5DB4E4CBC4A7954CFDA35E5"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "0F0377A205004F6990D8922178323D2E"
+                        ]
+                },
+                {
+                        x: 15.0d
+                        y: 122.0d
+                        id: "57F9C1E15D594B3ABDE77B7794D278B9"
+                        title: "Progression : Waterframes Forge"
+                        icon: {
+                                id: "waterframes:frame"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "F96332EE66E54910BB6C6ED77D412429"
+                                        type: "item"
+                                        item: {
+                                                id: "waterframes:frame"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "E321E9D2AC604A81A9192453BC848BC0"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "00B9D02B9FCA4010A524FC6C8252ECCA"
+                        ]
+                },
+                {
+                        x: 15.0d
+                        y: 124.0d
+                        id: "06B1C573972045E7AD1AB68D1A992E8E"
+                        title: "Ma\u00eetrise : Waterframes Forge"
+                        icon: {
+                                id: "waterframes:projector"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "2EFBDD387330483E8E0CB940256D4FBE"
+                                        type: "item"
+                                        item: {
+                                                id: "waterframes:projector"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "CBC641B92621417FB050663CD1F06312"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "57F9C1E15D594B3ABDE77B7794D278B9"
+                        ]
+                },
+                {
+                        x: 20.0d
+                        y: 120.0d
+                        id: "E328EBCE91054784B63767F874C33EDB"
+                        title: "D\u00e9couverte : Waystones Forge"
+                        icon: {
+                                id: "waystones:attuned_shard"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "F7670F3B69324127B83001E2FA4C74D2"
+                                        type: "item"
+                                        item: {
+                                                id: "waystones:attuned_shard"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "01B635CDD4F8482190D8B1B337A046BC"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "06B1C573972045E7AD1AB68D1A992E8E"
+                        ]
+                },
+                {
+                        x: 20.0d
+                        y: 122.0d
+                        id: "C7DBD2D8571448C08C5755F9E3387D72"
+                        title: "Progression : Waystones Forge"
+                        icon: {
+                                id: "waystones:black_sharestone"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "DCCA088BFB7143B0B466D53F32169BB1"
+                                        type: "item"
+                                        item: {
+                                                id: "waystones:black_sharestone"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "C8BA2694C5144312A370FDBDE06465B8"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "E328EBCE91054784B63767F874C33EDB"
+                        ]
+                },
+                {
+                        x: 20.0d
+                        y: 124.0d
+                        id: "1E6DFC0B9BCF423181DD4ACE7EE95425"
+                        title: "Ma\u00eetrise : Waystones Forge"
+                        icon: {
+                                id: "waystones:blue_sharestone"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "4E383F8285894581B64062954E2C7885"
+                                        type: "item"
+                                        item: {
+                                                id: "waystones:blue_sharestone"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "0559FD13DAED40E09DD9F5A6093BFCDE"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "C7DBD2D8571448C08C5755F9E3387D72"
+                        ]
+                },
+                {
+                        x: 25.0d
+                        y: 120.0d
+                        id: "6AC87460F67A4676AFC384F1ED5257F9"
+                        title: "D\u00e9couverte : Zerocore2"
+                        icon: {
+                                id: "zerocore:debugtool"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "64A85BFF121F4F71A1E0CA9207974B63"
+                                        type: "item"
+                                        item: {
+                                                id: "zerocore:debugtool"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "66590AE1E22C404697464CE2125F1BA0"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "1E6DFC0B9BCF423181DD4ACE7EE95425"
+                        ]
+                },
+                {
+                        x: 0.0d
+                        y: 128.0d
+                        id: "DA6C7583608D4D00A29C9925A78AFDAD"
+                        title: "D\u00e9couverte : [1.18.2] Securitycraft V1.10"
+                        icon: {
+                                id: "securitycraft:admin_tool"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "802DB5B045A946EEB922A82E6704AEB6"
+                                        type: "item"
+                                        item: {
+                                                id: "securitycraft:admin_tool"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "A98A716441334EF784C4298F5F2A6279"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "6AC87460F67A4676AFC384F1ED5257F9"
+                        ]
+                },
+                {
+                        x: 0.0d
+                        y: 130.0d
+                        id: "9316F94DA1254C128143B9CD5598A07A"
+                        title: "Progression : [1.18.2] Securitycraft V1.10"
+                        icon: {
+                                id: "securitycraft:alarm"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "64CA2F900A2A43598815E3CC235C92FB"
+                                        type: "item"
+                                        item: {
+                                                id: "securitycraft:alarm"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "90CB949F05BA413DB8973CDC578F2B47"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "DA6C7583608D4D00A29C9925A78AFDAD"
+                        ]
+                },
+                {
+                        x: 0.0d
+                        y: 132.0d
+                        id: "94C9BC4823914F1B9DB61FD65066FC7B"
+                        title: "Ma\u00eetrise : [1.18.2] Securitycraft V1.10"
+                        icon: {
+                                id: "securitycraft:ancient_debris_mine"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "34248321DE36488CBAF0622C7A272976"
+                                        type: "item"
+                                        item: {
+                                                id: "securitycraft:ancient_debris_mine"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "3AC1B35BE0104A0C849B3677188C5FE9"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "9316F94DA1254C128143B9CD5598A07A"
+                        ]
+                }
+        ]
+}

--- a/Survie/minecraft/config/ftbquests/quests/chapters/mods_tech_gen.snbt
+++ b/Survie/minecraft/config/ftbquests/quests/chapters/mods_tech_gen.snbt
@@ -1,0 +1,312 @@
+{
+        id: "4C6508BDA0D548AFBDDACA5BB6382376"
+        group: ""
+        order_index: 1
+        filename: "mods_tech_gen"
+        title: "Technologie"
+        icon: {
+                id: "minecraft:redstone"
+                Count: 1b
+        }
+        default_quest_shape: ""
+        default_hide_dependency_lines: false
+        quests: [
+                {
+                        x: 0.0d
+                        y: 0.0d
+                        id: "C79FE9DC39224FF589F54FAFF7D4D629"
+                        title: "D\u00e9couverte : Clickmachine"
+                        icon: {
+                                id: "clickmachine:auto_clicker"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "AD98DF0E33D84C88A3E77F2F3B61E4CB"
+                                        type: "item"
+                                        item: {
+                                                id: "clickmachine:auto_clicker"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "94A7AE778AAE4E8D9D6B4AD57B3CA6DD"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                },
+                {
+                        x: 5.0d
+                        y: 0.0d
+                        id: "7653F32AEA73490B92179CB7CCA2B073"
+                        title: "D\u00e9couverte : Mekanism"
+                        icon: {
+                                id: "mekanism:advanced_bin"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "B7121BF80C804060A6D3F20AEDC406B4"
+                                        type: "item"
+                                        item: {
+                                                id: "mekanism:advanced_bin"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "ADFA008586704F85A3334A148A8923C6"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "C79FE9DC39224FF589F54FAFF7D4D629"
+                        ]
+                },
+                {
+                        x: 5.0d
+                        y: 2.0d
+                        id: "2F32CC7E988D420A9742C57C4929E283"
+                        title: "Progression : Mekanism"
+                        icon: {
+                                id: "mekanism:advanced_bounding_block"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "3B5BFBA12EF7478686C10368116B2ACD"
+                                        type: "item"
+                                        item: {
+                                                id: "mekanism:advanced_bounding_block"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "8320A1995E8C41BF998F40E04E0ED895"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "7653F32AEA73490B92179CB7CCA2B073"
+                        ]
+                },
+                {
+                        x: 5.0d
+                        y: 4.0d
+                        id: "F9F3E714A6B445688FDD940B19F0F8BF"
+                        title: "Ma\u00eetrise : Mekanism"
+                        icon: {
+                                id: "mekanism:advanced_chemical_tank"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "0052DE4BFF724AB1AAB0949AC01856EC"
+                                        type: "item"
+                                        item: {
+                                                id: "mekanism:advanced_chemical_tank"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "681F33DCBDD84D2D997F43DE6F331249"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "2F32CC7E988D420A9742C57C4929E283"
+                        ]
+                },
+                {
+                        x: 10.0d
+                        y: 0.0d
+                        id: "FE51727E5C0C4E0783211C5427E8B6CD"
+                        title: "D\u00e9couverte : Mekanismgenerators"
+                        icon: {
+                                id: "mekanismgenerators:advanced_solar_generator"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "F848218F78CA448ABB8D62A71D616D57"
+                                        type: "item"
+                                        item: {
+                                                id: "mekanismgenerators:advanced_solar_generator"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "AB00D62740654FD59DC25797B7D694B7"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "F9F3E714A6B445688FDD940B19F0F8BF"
+                        ]
+                },
+                {
+                        x: 10.0d
+                        y: 2.0d
+                        id: "4252F72CFEF740C7879A7BBF8FB7098B"
+                        title: "Progression : Mekanismgenerators"
+                        icon: {
+                                id: "mekanismgenerators:bio_generator"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "5602BBEA5BD0405E9086051EC466A163"
+                                        type: "item"
+                                        item: {
+                                                id: "mekanismgenerators:bio_generator"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "75B372321CEA4A38BF4EAE1A92C30E3A"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "FE51727E5C0C4E0783211C5427E8B6CD"
+                        ]
+                },
+                {
+                        x: 10.0d
+                        y: 4.0d
+                        id: "7A2BA618C50948E081CBC7260C5DB658"
+                        title: "Ma\u00eetrise : Mekanismgenerators"
+                        icon: {
+                                id: "mekanismgenerators:bioethanol_bucket"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "8766C5F6C94F4CADB60D99E853E32F1A"
+                                        type: "item"
+                                        item: {
+                                                id: "mekanismgenerators:bioethanol_bucket"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "15601861ACC14D61A241DEFABF4FF013"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "4252F72CFEF740C7879A7BBF8FB7098B"
+                        ]
+                },
+                {
+                        x: 15.0d
+                        y: 0.0d
+                        id: "126E678A5B024A3F88D82B4B8EBAEDA1"
+                        title: "D\u00e9couverte : Mekanismtools"
+                        icon: {
+                                id: "mekanismtools:bronze_axe"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "1E27B392AE594671972B39F85D3CAFBC"
+                                        type: "item"
+                                        item: {
+                                                id: "mekanismtools:bronze_axe"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "ED816F579C8042678E02B8E72898742A"
+                                        type: "xp"
+                                        xp: 100
+                                }
+                        ]
+                        dependencies: [
+                                "7A2BA618C50948E081CBC7260C5DB658"
+                        ]
+                },
+                {
+                        x: 15.0d
+                        y: 2.0d
+                        id: "DB9421491C35409EA0A8633AAFBBA940"
+                        title: "Progression : Mekanismtools"
+                        icon: {
+                                id: "mekanismtools:bronze_boots"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "0BDFC21E1478485EBD337CDABD44B200"
+                                        type: "item"
+                                        item: {
+                                                id: "mekanismtools:bronze_boots"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "DA044954D29148F79D6E5101817AAEA6"
+                                        type: "xp"
+                                        xp: 200
+                                }
+                        ]
+                        dependencies: [
+                                "126E678A5B024A3F88D82B4B8EBAEDA1"
+                        ]
+                },
+                {
+                        x: 15.0d
+                        y: 4.0d
+                        id: "41A67353A61D4EDCA53C49F091EB4BCF"
+                        title: "Ma\u00eetrise : Mekanismtools"
+                        icon: {
+                                id: "mekanismtools:bronze_chestplate"
+                                Count: 1b
+                        }
+                        tasks: [
+                                {
+                                        id: "269E4749B0FA41BBAE889A7768355128"
+                                        type: "item"
+                                        item: {
+                                                id: "mekanismtools:bronze_chestplate"
+                                                Count: 1b
+                                        }
+                                }
+                        ]
+                        rewards: [
+                                {
+                                        id: "C6837230A25F47F08E9239DA9FDAB2B1"
+                                        type: "xp"
+                                        xp: 300
+                                }
+                        ]
+                        dependencies: [
+                                "DB9421491C35409EA0A8633AAFBBA940"
+                        ]
+                }
+        ]
+}

--- a/build_mod_quests.py
+++ b/build_mod_quests.py
@@ -1,0 +1,172 @@
+import zipfile, uuid, json, re
+from pathlib import Path
+
+mods_dir = Path('Survie/minecraft/mods')
+chapters_dir = Path('Survie/minecraft/config/ftbquests/quests/chapters')
+
+# Remove existing generated chapters
+for path in chapters_dir.glob('mods_*_gen.snbt'):
+    path.unlink()
+
+# categorization keywords
+categories = {
+    'tech': {
+        'title': 'Technologie',
+        'icon': 'minecraft:redstone',
+        'keywords': ['tech', 'mekanism', 'thermal', 'engineer', 'industrial', 'power', 'factory', 'automation', 'machine', 'energy', 'industrial', 'electric']
+    },
+    'magic': {
+        'title': 'Magie',
+        'icon': 'minecraft:enchanted_book',
+        'keywords': ['magic', 'magie', 'spell', 'arcane', 'wizard', 'botania', 'ars', 'mana', 'apotheosis', 'mystic', 'sorcer', 'enchanted']
+    },
+    'agri': {
+        'title': 'Agriculture',
+        'icon': 'minecraft:wheat',
+        'keywords': ['farm', 'crop', 'agri', 'plant', 'harvest', 'food', 'culinary', 'cuisine']
+    },
+    'explore': {
+        'title': 'Exploration',
+        'icon': 'minecraft:compass',
+        'keywords': ['explor', 'biome', 'dungeon', 'quest', 'adventure', 'aether', 'earth', 'minecolon', 'twilight', 'end', 'nether']
+    },
+    'other': {
+        'title': 'Divers',
+        'icon': 'minecraft:chest',
+        'keywords': []
+    }
+}
+
+# helper to classify mod by jar name
+
+def classify(name: str):
+    lname = name.lower()
+    for key, data in categories.items():
+        for kw in data['keywords']:
+            if kw in lname:
+                return key
+    return 'other'
+
+
+def clean_name(name: str) -> str:
+    """Return a user friendly mod name."""
+    name = re.sub(r'[-_](?:mc)?\d.*', '', name)
+    name = re.sub(r'[-_]+', ' ', name)
+    return name.strip().title()
+
+# Build mods data
+mods_by_category = {key: [] for key in categories}
+
+for jar in mods_dir.glob('*.jar'):
+    try:
+        with zipfile.ZipFile(jar) as z:
+            names = z.namelist()
+            modids = {n.split('/')[1] for n in names if n.startswith('assets/')}
+            modids.discard('minecraft'); modids.discard('');
+            if not modids:
+                continue
+            modid = sorted(modids)[0]
+            items = [Path(n).stem for n in names if n.startswith(f'assets/{modid}/models/item/') and n.endswith('.json')]
+            if not items:
+                continue
+            items = sorted(set(items))[:3]
+            modname = jar.stem
+            cat = classify(modname)
+            mods_by_category[cat].append({
+                'modid': modid,
+                'modname': modname,
+                'clean_name': clean_name(modname),
+                'items': items
+            })
+    except zipfile.BadZipFile:
+        pass
+
+# Generate chapters
+for order, (cat_key, data) in enumerate(categories.items(), start=1):
+    mods = mods_by_category[cat_key]
+    if not mods:
+        continue
+    chapter = {
+        'id': uuid.uuid4().hex.upper(),
+        'group': '',
+        'order_index': order,
+        'filename': f'mods_{cat_key}_gen',
+        'title': data['title'],
+        'icon': {'id': data['icon'], 'Count': '1b'},
+        'default_quest_shape': '',
+        'default_hide_dependency_lines': False,
+        'quests': []
+    }
+    cols = 6
+    spacing_x = 5
+    spacing_y = 8
+    prev_chain_last = None
+    for idx, mod in enumerate(sorted(mods, key=lambda m: m['clean_name'])):
+        col = idx % cols
+        row = idx // cols
+        x_base = col * spacing_x
+        y_base = row * spacing_y
+        prev_id = None
+        for qn, item in enumerate(mod['items'], start=1):
+            q_id = uuid.uuid4().hex.upper()
+            t_id = uuid.uuid4().hex.upper()
+            r_id = uuid.uuid4().hex.upper()
+            titles = ['Découverte', 'Progression', 'Maîtrise']
+            quest = {
+                'x': float(x_base),
+                'y': float(y_base + (qn-1)*2),
+                'id': q_id,
+                'title': f"{titles[qn-1]} : {mod['clean_name']}",
+                'icon': {'id': f"{mod['modid']}:{item}", 'Count': '1b'},
+                'tasks': [{
+                    'id': t_id,
+                    'type': 'item',
+                    'item': {'id': f"{mod['modid']}:{item}", 'Count': '1b'}
+                }],
+                'rewards': [{
+                    'id': r_id,
+                    'type': 'xp',
+                    'xp': 100 * qn
+                }]
+            }
+            if prev_id:
+                quest['dependencies'] = [prev_id]
+            elif prev_chain_last:
+                quest['dependencies'] = [prev_chain_last]
+            chapter['quests'].append(quest)
+            prev_id = q_id
+        prev_chain_last = prev_id
+    # write SNBT
+    def to_snbt(obj, indent=0):
+        sp = '        '
+        if isinstance(obj, dict):
+            if not obj:
+                return '{ }'
+            lines = ['{']
+            for k, v in obj.items():
+                lines.append(f"{sp*(indent+1)}{k}: {to_snbt(v, indent+1)}")
+            lines.append(f"{sp*indent}}}")
+            return '\n'.join(lines)
+        elif isinstance(obj, list):
+            if not obj:
+                return '[]'
+            lines = ['[']
+            for i, v in enumerate(obj):
+                comma = ',' if i < len(obj)-1 else ''
+                lines.append(f"{sp*(indent+1)}{to_snbt(v, indent+1)}{comma}")
+            lines.append(f"{sp*indent}]")
+            return '\n'.join(lines)
+        elif isinstance(obj, bool):
+            return 'true' if obj else 'false'
+        elif isinstance(obj, float):
+            return f"{obj:.1f}d"
+        elif isinstance(obj, int):
+            return str(obj)
+        elif isinstance(obj, str) and obj.endswith('b') and obj[:-1].isdigit():
+            return obj
+        else:
+            return json.dumps(obj)
+
+    snbt = '{\n' + '\n'.join(f"        {k}: {to_snbt(v,1)}" for k,v in chapter.items()) + '\n}\n'
+    out_path = chapters_dir / f"mods_{cat_key}_gen.snbt"
+    out_path.write_text(snbt, encoding='utf-8')


### PR DESCRIPTION
## Summary
- clean mod names and auto-generate quests in a compact grid with sequential dependencies
- script now lays out each mod's quest chain vertically and links between chains for logical progression

## Testing
- `rg 'minecraft:book' -n Survie/minecraft/config/ftbquests/quests/chapters`
- `python -m py_compile build_mod_quests.py`


------
https://chatgpt.com/codex/tasks/task_e_68c56d422fc48333bf09a36cab21fcf0